### PR TITLE
Use STAGING infura token by default and prod only for prod builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ env:
   REACT_APP_GOOGLE_ANALYTICS: ${{ secrets.REACT_APP_GOOGLE_ANALYTICS_ID_MAINNET }}
   REACT_APP_ETHERSCAN_API_KEY: ${{ secrets.REACT_APP_ETHERSCAN_API_KEY }}
   REACT_APP_ETHGASSTATION_API_KEY: ${{ secrets.REACT_APP_ETHGASSTATION_API_KEY }}
+  REACT_APP_INFURA_TOKEN: ${{ secrets.REACT_APP_INFURA_TOKEN_STAGING }}
 
 jobs:
   debug:
@@ -80,14 +81,15 @@ jobs:
 
       # Set production flag on prod
       - name: Set production flag for release PR or tagged build
-        run: echo "REACT_APP_ENV=production" >> $GITHUB_ENV
+        run: | 
+          echo "REACT_APP_ENV=production" >> $GITHUB_ENV
+          echo "REACT_APP_INFURA_TOKEN=${{ secrets.REACT_APP_INFURA_TOKEN }}" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/v') || github.base_ref == 'main'
 
       - name: Build app
         run: yarn build
         env:
           REACT_APP_FORTMATIC_KEY: ${{ secrets.REACT_APP_FORTMATIC_KEY }}
-          REACT_APP_INFURA_TOKEN: ${{ secrets.REACT_APP_INFURA_TOKEN }}
           REACT_APP_SAFE_APPS_RPC_INFURA_TOKEN: ${{ secrets.REACT_APP_SAFE_APPS_RPC_INFURA_TOKEN }}
           REACT_APP_PORTIS_ID: ${{ secrets.REACT_APP_PORTIS_ID }}
           REACT_APP_INTERCOM_ID: ${{ secrets.REACT_APP_INTERCOM_ID }}


### PR DESCRIPTION
## What it solves
We need to use a different Infura key for production environment. This way we will be also able to test whitelisting domains to ensure that our Infura API key is limited for Gnosis Safe app

## How this PR fixes it
We are adding a new key for PR, Staging and Dev environment that will be used by Raul to test that he is able to whitelist/blacklist as necessary
