### PR TITLE
fix: Sync current safe address into store

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -13,7 +13,7 @@ import { SafeListSidebar, SafeListSidebarContext } from 'src/components/SafeList
 import CookiesBanner from 'src/components/CookiesBanner'
 import Notifier from 'src/components/Notifier'
 import Img from 'src/components/layout/Img'
-import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
+import { safesWithNamesAsMap } from 'src/logic/safe/store/selectors'
 import { currentCurrencySelector } from 'src/logic/currencyValues/store/selectors'
 import Modal from 'src/components/Modal'
 import SendModal from 'src/routes/safe/components/Balances/SendModal'
@@ -23,6 +23,7 @@ import { grantedSelector } from 'src/routes/safe/container/selector'
 import ReceiveModal from './ReceiveModal'
 import { useSidebarItems } from 'src/components/AppLayout/Sidebar/useSidebarItems'
 import useAddressBookSync from 'src/logic/addressBook/hooks/useAddressBookSync'
+import { extractSafeAddress } from 'src/routes/routes'
 
 const notificationStyles = {
   success: {
@@ -51,12 +52,13 @@ const useStyles = makeStyles(notificationStyles)
 const App: React.FC = ({ children }) => {
   const classes = useStyles()
   const { toggleSidebar } = useContext(SafeListSidebarContext)
-  const { name: safeName, totalFiatBalance: currentSafeBalance } = useSelector(currentSafeWithNames)
+  const safesAsMap = useSelector(safesWithNamesAsMap)
   const { safeActionsState, onShow, onHide, showSendFunds, hideSendFunds } = useSafeActions()
   const currentCurrency = useSelector(currentCurrencySelector)
   const granted = useSelector(grantedSelector)
   const sidebarItems = useSidebarItems()
-  const { address: safeAddress } = useSelector(currentSafeWithNames)
+  const safeAddress = extractSafeAddress()
+  const { address, name: safeName, totalFiatBalance: currentSafeBalance } = safesAsMap[safeAddress]
 
   useAddressBookSync()
 
@@ -91,7 +93,7 @@ const App: React.FC = ({ children }) => {
 
           <AppLayout
             sidebarItems={sidebarItems}
-            safeAddress={safeAddress}
+            safeAddress={address}
             safeName={safeName}
             balance={balance}
             granted={granted}

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -13,7 +13,7 @@ import { SafeListSidebar, SafeListSidebarContext } from 'src/components/SafeList
 import CookiesBanner from 'src/components/CookiesBanner'
 import Notifier from 'src/components/Notifier'
 import Img from 'src/components/layout/Img'
-import { safesWithNamesAsMap } from 'src/logic/safe/store/selectors'
+import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { currentCurrencySelector } from 'src/logic/currencyValues/store/selectors'
 import Modal from 'src/components/Modal'
 import SendModal from 'src/routes/safe/components/Balances/SendModal'
@@ -23,7 +23,7 @@ import { grantedSelector } from 'src/routes/safe/container/selector'
 import ReceiveModal from './ReceiveModal'
 import { useSidebarItems } from 'src/components/AppLayout/Sidebar/useSidebarItems'
 import useAddressBookSync from 'src/logic/addressBook/hooks/useAddressBookSync'
-import { extractSafeAddress } from 'src/routes/routes'
+import { useCurrentSafeAddressSync } from 'src/logic/currentSession/hooks/useCurrentSafeAddressSync'
 
 const notificationStyles = {
   success: {
@@ -52,14 +52,14 @@ const useStyles = makeStyles(notificationStyles)
 const App: React.FC = ({ children }) => {
   const classes = useStyles()
   const { toggleSidebar } = useContext(SafeListSidebarContext)
-  const safesAsMap = useSelector(safesWithNamesAsMap)
+  const { name: safeName, totalFiatBalance: currentSafeBalance } = useSelector(currentSafeWithNames)
   const { safeActionsState, onShow, onHide, showSendFunds, hideSendFunds } = useSafeActions()
   const currentCurrency = useSelector(currentCurrencySelector)
   const granted = useSelector(grantedSelector)
   const sidebarItems = useSidebarItems()
-  const safeAddress = extractSafeAddress()
-  const { address, name: safeName, totalFiatBalance: currentSafeBalance } = safesAsMap[safeAddress]
+  const { address: safeAddress } = useSelector(currentSafeWithNames)
 
+  useCurrentSafeAddressSync()
   useAddressBookSync()
 
   const sendFunds = safeActionsState.sendFunds
@@ -93,7 +93,7 @@ const App: React.FC = ({ children }) => {
 
           <AppLayout
             sidebarItems={sidebarItems}
-            safeAddress={address}
+            safeAddress={safeAddress}
             safeName={safeName}
             balance={balance}
             granted={granted}

--- a/src/logic/currentSession/hooks/useCurrentSafeAddressSync.ts
+++ b/src/logic/currentSession/hooks/useCurrentSafeAddressSync.ts
@@ -12,5 +12,5 @@ export const useCurrentSafeAddressSync = (): void => {
 
   useEffect(() => {
     dispatch(addCurrentSafeAddress(extractPrefixedSafeAddress(location.pathname).safeAddress))
-  }, [location, dispatch])
+  }, [location.pathname, dispatch])
 }

--- a/src/logic/currentSession/hooks/useCurrentSafeAddressSync.ts
+++ b/src/logic/currentSession/hooks/useCurrentSafeAddressSync.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+import { extractPrefixedSafeAddress, history } from 'src/routes/routes'
+import addCurrentSafeAddress from 'src/logic/currentSession/store/actions/addCurrentSafeAddress'
+import { useDispatch } from 'react-redux'
+import { Dispatch } from 'redux'
+
+export const useCurrentSafeAddressSync = (): void => {
+  const dispatch = useDispatch<Dispatch>()
+
+  useEffect(() => {
+    dispatch(addCurrentSafeAddress(extractPrefixedSafeAddress(location.pathname).safeAddress))
+
+    const unsubscribe = history.listen((location) => {
+      dispatch(addCurrentSafeAddress(extractPrefixedSafeAddress(location.pathname).safeAddress))
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [dispatch])
+}

--- a/src/logic/currentSession/hooks/useCurrentSafeAddressSync.ts
+++ b/src/logic/currentSession/hooks/useCurrentSafeAddressSync.ts
@@ -8,7 +8,7 @@ export const useCurrentSafeAddressSync = (): void => {
   const dispatch = useDispatch<Dispatch>()
 
   useEffect(() => {
-    dispatch(addCurrentSafeAddress(extractPrefixedSafeAddress(location.pathname).safeAddress))
+    dispatch(addCurrentSafeAddress(extractPrefixedSafeAddress(history.location.pathname).safeAddress))
 
     const unsubscribe = history.listen((location) => {
       dispatch(addCurrentSafeAddress(extractPrefixedSafeAddress(location.pathname).safeAddress))

--- a/src/logic/currentSession/hooks/useCurrentSafeAddressSync.ts
+++ b/src/logic/currentSession/hooks/useCurrentSafeAddressSync.ts
@@ -1,21 +1,16 @@
 import { useEffect } from 'react'
-import { extractPrefixedSafeAddress, history } from 'src/routes/routes'
-import addCurrentSafeAddress from 'src/logic/currentSession/store/actions/addCurrentSafeAddress'
-import { useDispatch } from 'react-redux'
 import { Dispatch } from 'redux'
+import { useDispatch } from 'react-redux'
+import { useLocation } from 'react-router-dom'
+
+import { extractPrefixedSafeAddress } from 'src/routes/routes'
+import addCurrentSafeAddress from 'src/logic/currentSession/store/actions/addCurrentSafeAddress'
 
 export const useCurrentSafeAddressSync = (): void => {
   const dispatch = useDispatch<Dispatch>()
+  const location = useLocation()
 
   useEffect(() => {
-    dispatch(addCurrentSafeAddress(extractPrefixedSafeAddress(history.location.pathname).safeAddress))
-
-    const unsubscribe = history.listen((location) => {
-      dispatch(addCurrentSafeAddress(extractPrefixedSafeAddress(location.pathname).safeAddress))
-    })
-
-    return () => {
-      unsubscribe()
-    }
-  }, [dispatch])
+    dispatch(addCurrentSafeAddress(extractPrefixedSafeAddress(location.pathname).safeAddress))
+  }, [location, dispatch])
 }

--- a/src/logic/currentSession/store/actions/addCurrentSafeAddress.ts
+++ b/src/logic/currentSession/store/actions/addCurrentSafeAddress.ts
@@ -1,0 +1,7 @@
+import { createAction } from 'redux-actions'
+
+export const ADD_CURRENT_SAFE_ADDRESS = 'ADD_CURRENT_SAFE_ADDRESS'
+
+const addCurrentSafeAddress = createAction<string>(ADD_CURRENT_SAFE_ADDRESS)
+
+export default addCurrentSafeAddress

--- a/src/logic/currentSession/store/reducer/currentSession.ts
+++ b/src/logic/currentSession/store/reducer/currentSession.ts
@@ -5,17 +5,20 @@ import { UPDATE_VIEWED_SAFES } from 'src/logic/currentSession/store/actions/upda
 import { CLEAR_CURRENT_SESSION } from 'src/logic/currentSession/store/actions/clearCurrentSession'
 import { saveCurrentSessionToStorage } from 'src/logic/currentSession/utils'
 import { REMOVE_VIEWED_SAFE } from '../actions/removeViewedSafe'
+import { ADD_CURRENT_SAFE_ADDRESS } from 'src/logic/currentSession/store/actions/addCurrentSafeAddress'
 
 export const CURRENT_SESSION_REDUCER_ID = 'currentSession'
 const MAX_VIEWED_SAFES = 10
 
 export type CurrentSessionState = {
   viewedSafes: string[]
+  currentSafeAddress: string
   restored: boolean
 }
 
 export const initialState = {
   viewedSafes: [],
+  currentSafeAddress: '',
   restored: false,
 }
 
@@ -53,6 +56,15 @@ const currentSessionReducer = handleActions<CurrentSessionState, CurrentSessionP
     },
     [CLEAR_CURRENT_SESSION]: () => {
       return initialState
+    },
+    [ADD_CURRENT_SAFE_ADDRESS]: (state, action: Action<string>) => {
+      const safeAddress = action.payload
+      const newState = {
+        ...state,
+        currentSafeAddress: safeAddress,
+      }
+
+      return newState
     },
   },
   initialState,

--- a/src/logic/currentSession/store/selectors/index.ts
+++ b/src/logic/currentSession/store/selectors/index.ts
@@ -8,3 +8,5 @@ export const lastViewedSafe = (state: AppReduxState['currentSession']): string |
   }
   return currentSession.viewedSafes[0] || ''
 }
+
+export const currentSafeAddress = (state: AppReduxState): string => state[CURRENT_SESSION_REDUCER_ID].currentSafeAddress

--- a/src/logic/currentSession/store/selectors/index.ts
+++ b/src/logic/currentSession/store/selectors/index.ts
@@ -1,4 +1,6 @@
-import { CURRENT_SESSION_REDUCER_ID } from 'src/logic/currentSession/store/reducer/currentSession'
+import { createSelector } from 'reselect'
+
+import { CURRENT_SESSION_REDUCER_ID, CurrentSessionState } from 'src/logic/currentSession/store/reducer/currentSession'
 import { AppReduxState } from 'src/store'
 
 export const lastViewedSafe = (state: AppReduxState['currentSession']): string | null => {
@@ -9,4 +11,6 @@ export const lastViewedSafe = (state: AppReduxState['currentSession']): string |
   return currentSession.viewedSafes[0] || ''
 }
 
-export const currentSafeAddress = (state: AppReduxState): string => state[CURRENT_SESSION_REDUCER_ID].currentSafeAddress
+export const currentSession = (state: AppReduxState): CurrentSessionState => state[CURRENT_SESSION_REDUCER_ID]
+
+export const currentSafeAddress = createSelector(currentSession, (session) => session.currentSafeAddress)

--- a/src/logic/safe/store/reducer/gatewayTransactions.ts
+++ b/src/logic/safe/store/reducer/gatewayTransactions.ts
@@ -1,6 +1,7 @@
 import get from 'lodash/get'
 import cloneDeep from 'lodash/cloneDeep'
 import { Action, handleActions } from 'redux-actions'
+import { LabelValue } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import {
   ADD_HISTORY_TRANSACTIONS,
@@ -15,8 +16,8 @@ import {
   StoreStructure,
   Transaction,
 } from 'src/logic/safe/store/models/types/gateway.d'
-import { UPDATE_TRANSACTION_DETAILS } from 'src/logic/safe/store/actions/fetchTransactionDetails'
 
+import { UPDATE_TRANSACTION_DETAILS } from 'src/logic/safe/store/actions/fetchTransactionDetails'
 import { getLocalStartOfDate } from 'src/utils/date'
 import { sameString } from 'src/utils/strings'
 import { sortObject } from 'src/utils/objects'
@@ -118,7 +119,7 @@ export const gatewayTransactionsReducer = handleActions<GatewayTransactionsState
       // If there's no "Queued" label, put all the items into the "next" group.
       let nextItems = values
       let queuedItems = values.slice(0, 0)
-      const qLabelIndex = values.findIndex((item) => isLabel(item) && item.label === 'Queued')
+      const qLabelIndex = values.findIndex((item) => isLabel(item) && item.label === LabelValue.Queued)
       if (qLabelIndex >= 0) {
         nextItems = values.slice(0, qLabelIndex)
         queuedItems = values.slice(qLabelIndex)

--- a/src/logic/safe/store/reducer/gatewayTransactions.ts
+++ b/src/logic/safe/store/reducer/gatewayTransactions.ts
@@ -1,7 +1,6 @@
 import get from 'lodash/get'
 import cloneDeep from 'lodash/cloneDeep'
 import { Action, handleActions } from 'redux-actions'
-import { LabelValue } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import {
   ADD_HISTORY_TRANSACTIONS,
@@ -119,7 +118,7 @@ export const gatewayTransactionsReducer = handleActions<GatewayTransactionsState
       // If there's no "Queued" label, put all the items into the "next" group.
       let nextItems = values
       let queuedItems = values.slice(0, 0)
-      const qLabelIndex = values.findIndex((item) => isLabel(item) && item.label === LabelValue.Queued)
+      const qLabelIndex = values.findIndex((item) => isLabel(item) && item.label === 'Queued')
       if (qLabelIndex >= 0) {
         nextItems = values.slice(0, qLabelIndex)
         queuedItems = values.slice(qLabelIndex)

--- a/src/logic/safe/store/selectors/index.ts
+++ b/src/logic/safe/store/selectors/index.ts
@@ -6,9 +6,9 @@ import { currentChainId } from 'src/logic/config/store/selectors'
 import makeSafe, { SafeRecord, SafeRecordProps } from 'src/logic/safe/store/models/safe'
 import { SAFE_REDUCER_ID } from 'src/logic/safe/store/reducer/safe'
 import { SafesMap } from 'src/logic/safe/store/reducer/types/safe'
-import { extractSafeAddress } from 'src/routes/routes'
 import { AppReduxState } from 'src/store'
 import { Overwrite } from 'src/types/helpers'
+import { CURRENT_SESSION_REDUCER_ID } from 'src/logic/currentSession/store/reducer/currentSession'
 
 const safesState = (state: AppReduxState) => state[SAFE_REDUCER_ID]
 
@@ -20,12 +20,11 @@ export const latestMasterContractVersion = createSelector(safesState, (safeState
   safeState.get('latestMasterContractVersion'),
 )
 
-export const currentSafe = createSelector(
-  [safesAsMap, () => extractSafeAddress()],
-  (safes: SafesMap, address: string) => {
-    return safes.get(address, baseSafe(address)) ?? {}
-  },
-)
+export const currentSafeAddress = (state: AppReduxState): string => state[CURRENT_SESSION_REDUCER_ID].currentSafeAddress
+
+export const currentSafe = createSelector([safesAsMap, currentSafeAddress], (safes: SafesMap, address: string) => {
+  return safes.get(address, baseSafe(address)) ?? {}
+})
 
 const baseSafe = (address = '') => makeSafe({ address })
 

--- a/src/logic/safe/store/selectors/index.ts
+++ b/src/logic/safe/store/selectors/index.ts
@@ -8,7 +8,7 @@ import { SAFE_REDUCER_ID } from 'src/logic/safe/store/reducer/safe'
 import { SafesMap } from 'src/logic/safe/store/reducer/types/safe'
 import { AppReduxState } from 'src/store'
 import { Overwrite } from 'src/types/helpers'
-import { CURRENT_SESSION_REDUCER_ID } from 'src/logic/currentSession/store/reducer/currentSession'
+import { currentSafeAddress } from 'src/logic/currentSession/store/selectors'
 
 const safesState = (state: AppReduxState) => state[SAFE_REDUCER_ID]
 
@@ -19,8 +19,6 @@ export const safesAsList = createSelector(safesAsMap, (safes): List<SafeRecord> 
 export const latestMasterContractVersion = createSelector(safesState, (safeState) =>
   safeState.get('latestMasterContractVersion'),
 )
-
-export const currentSafeAddress = (state: AppReduxState): string => state[CURRENT_SESSION_REDUCER_ID].currentSafeAddress
 
 export const currentSafe = createSelector([safesAsMap, currentSafeAddress], (safes: SafesMap, address: string) => {
   return safes.get(address, baseSafe(address)) ?? {}

--- a/src/routes/safe/components/CurrencyDropdown/CurrencyDropdown.test.tsx
+++ b/src/routes/safe/components/CurrencyDropdown/CurrencyDropdown.test.tsx
@@ -58,6 +58,9 @@ describe('<CurrencyDropdown>', () => {
           },
         },
       },
+      currentSession: {
+        currentSafeAddress: safeAddress,
+      },
     }
     render(<CurrencyDropdown testId="testId" />, customState)
 

--- a/src/routes/safe/components/Settings/Advanced/Advanced.test.tsx
+++ b/src/routes/safe/components/Settings/Advanced/Advanced.test.tsx
@@ -84,6 +84,9 @@ describe('Advanced Settings Component', () => {
             },
           },
         },
+        currentSession: {
+          currentSafeAddress: safeAddress,
+        },
       }
 
       render(<Advanced />, customState)
@@ -138,6 +141,9 @@ describe('Advanced Settings Component', () => {
             },
           },
         },
+        currentSession: {
+          currentSafeAddress: safeAddress,
+        },
       }
 
       render(<Advanced />, customState)
@@ -166,6 +172,9 @@ describe('Advanced Settings Component', () => {
               currentVersion: '1.3.0',
             },
           },
+        },
+        currentSession: {
+          currentSafeAddress: safeAddress,
         },
       }
 
@@ -199,6 +208,9 @@ describe('Advanced Settings Component', () => {
               currentVersion: '1.3.0',
             },
           },
+        },
+        currentSession: {
+          currentSafeAddress: safeAddress,
         },
       }
 
@@ -264,6 +276,9 @@ describe('Advanced Settings Component', () => {
             },
           },
         },
+        currentSession: {
+          currentSafeAddress: safeAddress,
+        },
       }
 
       render(<Advanced />, customState)
@@ -294,6 +309,9 @@ describe('Advanced Settings Component', () => {
               currentVersion: '1.3.0',
             },
           },
+        },
+        currentSession: {
+          currentSafeAddress: safeAddress,
         },
       }
 


### PR DESCRIPTION
## What it solves
Resolves #3760 

## How this PR fixes it
Instead of relying on the `currentSafe` selector, we handle the logic inside the component by getting all safes from the store, extracting the current safe address from the url and finally selecting the current safe.

## How to test it
1. Open a Safe
2. Switch to a different Safe
3. Observe that Safe name, address, balance, icon updates in the sidebar