### PR TITLE
feat: Share Safe App button

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,18 +1,10 @@
 import { useContext } from 'react'
-import { makeStyles } from '@material-ui/core/styles'
-import { SnackbarProvider } from 'notistack'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 
-import AlertIcon from 'src/assets/icons/alert.svg'
-import CheckIcon from 'src/assets/icons/check.svg'
-import ErrorIcon from 'src/assets/icons/error.svg'
-import InfoIcon from 'src/assets/icons/info.svg'
 import AppLayout from 'src/components/AppLayout'
 import { SafeListSidebar, SafeListSidebarContext } from 'src/components/SafeListSidebar'
 import CookiesBanner from 'src/components/CookiesBanner'
-import Notifier from 'src/components/Notifier'
-import Img from 'src/components/layout/Img'
 import { currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import { currentCurrencySelector } from 'src/logic/currencyValues/store/selectors'
 import Modal from 'src/components/Modal'
@@ -24,21 +16,6 @@ import ReceiveModal from './ReceiveModal'
 import { useSidebarItems } from 'src/components/AppLayout/Sidebar/useSidebarItems'
 import useAddressBookSync from 'src/logic/addressBook/hooks/useAddressBookSync'
 
-const notificationStyles = {
-  success: {
-    background: '#fff',
-  },
-  error: {
-    background: '#ffe6ea',
-  },
-  warning: {
-    background: '#fff3e2',
-  },
-  info: {
-    background: '#fff',
-  },
-}
-
 const Frame = styled.div`
   display: flex;
   flex-direction: column;
@@ -46,10 +23,7 @@ const Frame = styled.div`
   max-width: 100%;
 `
 
-const useStyles = makeStyles(notificationStyles)
-
 const App: React.FC = ({ children }) => {
-  const classes = useStyles()
   const { toggleSidebar } = useContext(SafeListSidebarContext)
   const { name: safeName, totalFiatBalance: currentSafeBalance } = useSelector(currentSafeWithNames)
   const { safeActionsState, onShow, onHide, showSendFunds, hideSendFunds } = useSafeActions()
@@ -70,58 +44,37 @@ const App: React.FC = ({ children }) => {
 
   return (
     <Frame>
-      <SnackbarProvider
-        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-        classes={{
-          variantSuccess: classes.success,
-          variantError: classes.error,
-          variantWarning: classes.warning,
-          variantInfo: classes.info,
-        }}
-        iconVariant={{
-          error: <Img alt="Error" src={ErrorIcon} />,
-          info: <Img alt="Info" src={InfoIcon} />,
-          success: <Img alt="Success" src={CheckIcon} />,
-          warning: <Img alt="Warning" src={AlertIcon} />,
-        }}
-        maxSnack={5}
+      <AppLayout
+        sidebarItems={sidebarItems}
+        safeAddress={safeAddress}
+        safeName={safeName}
+        balance={balance}
+        granted={granted}
+        onToggleSafeList={toggleSidebar}
+        onReceiveClick={onReceiveShow}
+        onNewTransactionClick={() => showSendFunds('')}
       >
-        <>
-          <Notifier />
+        {children}
+      </AppLayout>
 
-          <AppLayout
-            sidebarItems={sidebarItems}
-            safeAddress={safeAddress}
-            safeName={safeName}
-            balance={balance}
-            granted={granted}
-            onToggleSafeList={toggleSidebar}
-            onReceiveClick={onReceiveShow}
-            onNewTransactionClick={() => showSendFunds('')}
-          >
-            {children}
-          </AppLayout>
+      <SendModal
+        activeScreenType="chooseTxType"
+        isOpen={sendFunds.isOpen}
+        onClose={hideSendFunds}
+        selectedToken={sendFunds.selectedToken}
+      />
 
-          <SendModal
-            activeScreenType="chooseTxType"
-            isOpen={sendFunds.isOpen}
-            onClose={hideSendFunds}
-            selectedToken={sendFunds.selectedToken}
-          />
-
-          {safeAddress && (
-            <Modal
-              description="Receive Tokens Form"
-              handleClose={onReceiveHide}
-              open={safeActionsState.showReceive}
-              paperClassName="receive-modal"
-              title="Receive Tokens"
-            >
-              <ReceiveModal onClose={onReceiveHide} safeAddress={safeAddress} safeName={safeName} />
-            </Modal>
-          )}
-        </>
-      </SnackbarProvider>
+      {safeAddress && (
+        <Modal
+          description="Receive Tokens Form"
+          handleClose={onReceiveHide}
+          open={safeActionsState.showReceive}
+          paperClassName="receive-modal"
+          title="Receive Tokens"
+        >
+          <ReceiveModal onClose={onReceiveHide} safeAddress={safeAddress} safeName={safeName} />
+        </Modal>
+      )}
       <CookiesBanner />
     </Frame>
   )

--- a/src/components/Providers/SnackbarProvider.tsx
+++ b/src/components/Providers/SnackbarProvider.tsx
@@ -1,0 +1,61 @@
+import { ReactNode } from 'react'
+import { SnackbarProvider } from 'notistack'
+import { makeStyles } from '@material-ui/core/styles'
+
+import Img from 'src/components/layout/Img'
+import AlertIcon from 'src/assets/icons/alert.svg'
+import CheckIcon from 'src/assets/icons/check.svg'
+import ErrorIcon from 'src/assets/icons/error.svg'
+import InfoIcon from 'src/assets/icons/info.svg'
+import Notifier from 'src/components/Notifier'
+
+type SnackBarProviderProps = {
+  children: ReactNode
+}
+
+const notificationStyles = {
+  success: {
+    background: '#fff',
+  },
+  error: {
+    background: '#ffe6ea',
+  },
+  warning: {
+    background: '#fff3e2',
+  },
+  info: {
+    background: '#fff',
+  },
+}
+
+const useStyles = makeStyles(notificationStyles)
+
+const CustomSnackBarProvider = ({ children }: SnackBarProviderProps): React.ReactElement => {
+  const classes = useStyles()
+
+  return (
+    <SnackbarProvider
+      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      classes={{
+        variantSuccess: classes.success,
+        variantError: classes.error,
+        variantWarning: classes.warning,
+        variantInfo: classes.info,
+      }}
+      iconVariant={{
+        error: <Img alt="Error" src={ErrorIcon} />,
+        info: <Img alt="Info" src={InfoIcon} />,
+        success: <Img alt="Success" src={CheckIcon} />,
+        warning: <Img alt="Warning" src={AlertIcon} />,
+      }}
+      maxSnack={5}
+    >
+      <>
+        {children}
+        <Notifier />
+      </>
+    </SnackbarProvider>
+  )
+}
+
+export default CustomSnackBarProvider

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from 'styled-components'
 import { Store } from 'redux'
 import { History } from 'history'
 import { theme } from '@gnosis.pm/safe-react-components'
+import SnackbarProvider from './SnackbarProvider'
 
 declare type Theme = typeof theme
 
@@ -22,7 +23,9 @@ function Providers({ children, store, styledTheme, muiTheme, history }: Provider
     <ThemeProvider theme={styledTheme}>
       <Provider store={store}>
         <MuiThemeProvider theme={muiTheme}>
-          <Router history={history}>{children}</Router>
+          <SnackbarProvider>
+            <Router history={history}>{children}</Router>
+          </SnackbarProvider>
         </MuiThemeProvider>
       </Provider>
     </ThemeProvider>

--- a/src/logic/notifications/notificationTypes.ts
+++ b/src/logic/notifications/notificationTypes.ts
@@ -57,6 +57,7 @@ enum NOTIFICATION_IDS {
   ADDRESS_BOOK_EXPORT_ENTRIES_SUCCESS,
   ADDRESS_BOOK_EXPORT_ENTRIES_ERROR,
   SAFE_NEW_VERSION_AVAILABLE,
+  SHARE_SAFE_APP_URL_COPIED,
 }
 
 export const NOTIFICATIONS: Record<NotificationId, Notification> = {
@@ -237,5 +238,11 @@ export const NOTIFICATIONS: Record<NotificationId, Notification> = {
   SAFE_NEW_VERSION_AVAILABLE: {
     message: 'There is a new version available for this Safe. Update now!',
     options: { variant: WARNING, persist: false, preventDuplicate: true },
+  },
+
+  // Copy to clipboard
+  SHARE_SAFE_APP_URL_COPIED: {
+    message: 'Safe App url copied to clipboard!',
+    options: { variant: INFO, persist: false, preventDuplicate: true },
   },
 }

--- a/src/logic/notifications/notificationTypes.ts
+++ b/src/logic/notifications/notificationTypes.ts
@@ -242,7 +242,7 @@ export const NOTIFICATIONS: Record<NotificationId, Notification> = {
 
   // Copy to clipboard
   SHARE_SAFE_APP_URL_COPIED: {
-    message: 'Safe App url copied to clipboard!',
+    message: 'Safe App URL copied to clipboard!',
     options: { variant: INFO, persist: false, preventDuplicate: true },
   },
 }

--- a/src/routes/routes.test.tsx
+++ b/src/routes/routes.test.tsx
@@ -8,10 +8,13 @@ import {
   ADDRESSED_ROUTE,
   history,
   LOAD_SPECIFIC_SAFE_ROUTE,
+  getShareSafeAppUrl,
+  SAFE_APP_LANDING_PAGE_ROUTE,
 } from './routes'
 import { Route, Switch } from 'react-router'
 import { render } from 'src/utils/test-utils'
 import { ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
+import { PUBLIC_URL } from 'src/utils/constants'
 
 const validSafeAddress = '0xF5A2915982BC8b0dEDda9cEF79297A83081Fe88f'
 
@@ -164,5 +167,18 @@ describe('generatePrefixedAddressRoutes', () => {
     )
 
     expect(hasAllPrefixedSafeAddressesRoutes).toBe(true)
+  })
+})
+
+describe('getShareSafeAppUrl', () => {
+  it('generates the share Safe App url', () => {
+    const appUrl = 'https://my-safe-app-url'
+    const chainId = '4'
+
+    expect(getShareSafeAppUrl(appUrl, chainId)).toBe(
+      `${window.location.origin}${PUBLIC_URL}${SAFE_APP_LANDING_PAGE_ROUTE}?appUrl=${encodeURI(
+        appUrl,
+      )}&chainId=${chainId}`,
+    )
   })
 })

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -132,3 +132,9 @@ export const demoSafeRoute = generateSafeRoute(SAFE_ROUTES.APPS, {
   shortName: 'eth',
   safeAddress: DEMO_SAFE_MAINNET,
 })
+
+export const getShareSafeAppUrl = (appUrl: string, chainId: string): string => {
+  const baseUrl = `${window.location.origin}${PUBLIC_URL}`
+
+  return `${baseUrl}${SAFE_APP_LANDING_PAGE_ROUTE}?appUrl=${encodeURI(appUrl)}&chainId=${chainId}`
+}

--- a/src/routes/safe/components/Apps/components/AppCard/index.tsx
+++ b/src/routes/safe/components/Apps/components/AppCard/index.tsx
@@ -13,11 +13,10 @@ import { motion } from 'framer-motion'
 import AddAppIcon from 'src/routes/safe/components/Apps/assets/addApp.svg'
 import { FETCH_STATUS } from 'src/utils/requests'
 import { SafeApp } from '../../types'
-import { PUBLIC_URL } from 'src/utils/constants'
 import appsIconSvg from 'src/assets/icons/apps.svg'
 import { AppIconSK, DescriptionSK, TitleSK } from './skeleton'
 import { copyToClipboard } from 'src/utils/clipboard'
-import { SAFE_APP_LANDING_PAGE_ROUTE } from 'src/routes/routes'
+import { getShareSafeAppUrl } from 'src/routes/routes'
 import { currentChainId } from 'src/logic/config/store/selectors'
 import enqueueSnackbar from 'src/logic/notifications/store/actions/enqueueSnackbar'
 import { enhanceSnackbarForAction, NOTIFICATIONS } from 'src/logic/notifications'
@@ -157,11 +156,7 @@ const AppCard = ({ app, iconSize = 'md', to, onPin, onRemove, pinned = false }: 
           // prevent triggering the link event
           e.preventDefault()
 
-          const baseUrl = `${window.location.origin}${PUBLIC_URL}`
-          const shareSafeAppUrl = `${baseUrl}${SAFE_APP_LANDING_PAGE_ROUTE}?appUrl=${encodeURI(
-            app.url,
-          )}&chainId=${chainId}`
-
+          const shareSafeAppUrl = getShareSafeAppUrl(app.url, chainId)
           copyToClipboard(shareSafeAppUrl)
 
           // we show a snackbar

--- a/src/routes/safe/components/Apps/components/AppCard/index.tsx
+++ b/src/routes/safe/components/Apps/components/AppCard/index.tsx
@@ -1,18 +1,26 @@
 import { SyntheticEvent } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
+import ShareIcon from '@material-ui/icons/Share'
 import Bookmark from '@material-ui/icons/Bookmark'
 import BookmarkBorder from '@material-ui/icons/BookmarkBorder'
 import { alpha } from '@material-ui/core/styles/colorManipulator'
 import IconButton from '@material-ui/core/IconButton'
 import { Title, Text, Button, Card, Icon } from '@gnosis.pm/safe-react-components'
 import { motion } from 'framer-motion'
+
 import AddAppIcon from 'src/routes/safe/components/Apps/assets/addApp.svg'
 import { FETCH_STATUS } from 'src/utils/requests'
 import { SafeApp } from '../../types'
-
+import { PUBLIC_URL } from 'src/utils/constants'
 import appsIconSvg from 'src/assets/icons/apps.svg'
 import { AppIconSK, DescriptionSK, TitleSK } from './skeleton'
+import { copyToClipboard } from 'src/utils/clipboard'
+import { SAFE_APP_LANDING_PAGE_ROUTE } from 'src/routes/routes'
+import { currentChainId } from 'src/logic/config/store/selectors'
+import enqueueSnackbar from 'src/logic/notifications/store/actions/enqueueSnackbar'
+import { enhanceSnackbarForAction, NOTIFICATIONS } from 'src/logic/notifications'
 
 const StyledAppCard = styled(Card)`
   display: flex;
@@ -41,7 +49,6 @@ const IconBtn = styled(IconButton)`
   &.MuiButtonBase-root {
     position: absolute;
     top: 10px;
-    right: 10px;
     z-index: 10;
     padding: 5px;
     opacity: 0;
@@ -52,6 +59,17 @@ const IconBtn = styled(IconButton)`
   svg {
     width: 16px;
     height: 16px;
+  }
+`
+const RightIconBtn = styled(IconBtn)`
+  &.MuiButtonBase-root {
+    right: 10px;
+  }
+`
+
+const LeftIconBtn = styled(IconBtn)`
+  &.MuiButtonBase-root {
+    left: 10px;
   }
 `
 
@@ -112,6 +130,9 @@ type RemoteAppProps = Shared & { onPin?: (app: SafeApp) => void; onRemove?: unde
 type Props = CustomAppProps | RemoteAppProps
 
 const AppCard = ({ app, iconSize = 'md', to, onPin, onRemove, pinned = false }: Props): React.ReactElement => {
+  const chainId = useSelector(currentChainId)
+  const dispatch = useDispatch()
+
   if (isAppLoading(app)) {
     return (
       <AppContainer layout initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
@@ -125,15 +146,37 @@ const AppCard = ({ app, iconSize = 'md', to, onPin, onRemove, pinned = false }: 
     )
   }
 
+  const shareSafeAppLabel = `Share ${app.name} Safe App`
+
   const content = (
     <>
+      <LeftIconBtn
+        aria-label={shareSafeAppLabel}
+        title={shareSafeAppLabel}
+        onClick={(e) => {
+          // prevent triggering the link event
+          e.preventDefault()
+
+          const baseUrl = `${window.location.origin}${PUBLIC_URL}`
+          const shareSafeAppUrl = `${baseUrl}${SAFE_APP_LANDING_PAGE_ROUTE}?appUrl=${encodeURI(
+            app.url,
+          )}&chainId=${chainId}`
+
+          copyToClipboard(shareSafeAppUrl)
+
+          // we show a snackbar
+          dispatch(enqueueSnackbar(enhanceSnackbarForAction(NOTIFICATIONS.SHARE_SAFE_APP_URL_COPIED)))
+        }}
+      >
+        <ShareIcon />
+      </LeftIconBtn>
       <StyledAppCard>
         <IconImg alt={`${app.name || 'App'} Logo`} src={app.iconUrl} onError={setAppImageFallback} size={iconSize} />
         <AppName size="xs">{app.name}</AppName>
         <AppDescription size="lg">{app.description} </AppDescription>
       </StyledAppCard>
       {onPin && (
-        <IconBtn
+        <RightIconBtn
           aria-label={getPinLabel(app.name, pinned)}
           title={getPinLabel(app.name, pinned)}
           onClick={(e) => {
@@ -144,11 +187,11 @@ const AppCard = ({ app, iconSize = 'md', to, onPin, onRemove, pinned = false }: 
           }}
         >
           {pinned ? <Bookmark /> : <BookmarkBorder />}
-        </IconBtn>
+        </RightIconBtn>
       )}
 
       {onRemove && (
-        <IconBtn
+        <RightIconBtn
           aria-label="Remove an app"
           title="Remove app"
           onClick={(e) => {
@@ -158,7 +201,7 @@ const AppCard = ({ app, iconSize = 'md', to, onPin, onRemove, pinned = false }: 
           }}
         >
           <Icon size="sm" type="delete" color="error" />
-        </IconBtn>
+        </RightIconBtn>
       )}
     </>
   )

--- a/src/routes/safe/components/Apps/components/AppsList.test.tsx
+++ b/src/routes/safe/components/Apps/components/AppsList.test.tsx
@@ -307,7 +307,7 @@ describe('Safe Apps -> AppsList -> Share Safe Apps', () => {
       // snackbar is not present
       expect(screen.queryByText('Safe App url copied to clipboard!')).not.toBeInTheDocument()
 
-      // snackbar is not present
+      // we click on the Share Safe App Button
       fireEvent.click(compoundAppShareBtn)
 
       const baseUrl = `${window.location.origin}${PUBLIC_URL}`

--- a/src/routes/safe/components/Apps/components/AppsList.test.tsx
+++ b/src/routes/safe/components/Apps/components/AppsList.test.tsx
@@ -6,8 +6,8 @@ import * as appUtils from 'src/routes/safe/components/Apps/utils'
 import { FETCH_STATUS } from 'src/utils/requests'
 import { loadFromStorage, saveToStorage } from 'src/utils/storage'
 import * as clipboard from 'src/utils/clipboard'
-import { PUBLIC_URL } from 'src/utils/constants'
-import { SAFE_APP_LANDING_PAGE_ROUTE } from 'src/routes/routes'
+import { getShareSafeAppUrl } from 'src/routes/routes'
+import { CHAIN_ID } from 'src/config/chain.d'
 
 jest.mock('src/routes/routes', () => {
   const original = jest.requireActual('src/routes/routes')
@@ -293,7 +293,7 @@ describe('Safe Apps -> AppsList -> Share Safe Apps', () => {
     })
   })
 
-  it('Copies the Safe app url to the clipboard and shows a snackbar', async () => {
+  it('Copies the Safe app URL to the clipboard and shows a snackbar', async () => {
     const copyToClipboardSpy = jest.spyOn(clipboard, 'copyToClipboard')
 
     copyToClipboardSpy.mockImplementation(() => jest.fn())
@@ -305,20 +305,19 @@ describe('Safe Apps -> AppsList -> Share Safe Apps', () => {
       const compoundAppShareBtn = within(allAppsContainer).getByLabelText('Share Compound Safe App')
 
       // snackbar is not present
-      expect(screen.queryByText('Safe App url copied to clipboard!')).not.toBeInTheDocument()
+      expect(screen.queryByText('Safe App URL copied to clipboard!')).not.toBeInTheDocument()
 
       // we click on the Share Safe App Button
       fireEvent.click(compoundAppShareBtn)
 
-      const baseUrl = `${window.location.origin}${PUBLIC_URL}`
       const compaundUrl = 'https://cloudflare-ipfs.com/ipfs/QmX31xCdhFDmJzoVG33Y6kJtJ5Ujw8r5EJJBrsp8Fbjm7k'
-      const shareSafeAppUrl = `${baseUrl}${SAFE_APP_LANDING_PAGE_ROUTE}?appUrl=${encodeURI(compaundUrl)}&chainId=4`
+      const shareSafeAppUrl = getShareSafeAppUrl(compaundUrl, CHAIN_ID.RINKEBY)
 
       // share Safe app url is copied in the clipboard
       expect(copyToClipboardSpy).toHaveBeenCalledWith(shareSafeAppUrl)
 
       // we show a snackbar
-      expect(screen.getByText('Safe App url copied to clipboard!')).toBeInTheDocument()
+      expect(screen.getByText('Safe App URL copied to clipboard!')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## What it solves
Resolves gnosis/safe-react-apps/issues/412

In this ticket we should continue with sharing Safe Apps problem statement. This will be focused on creating a share button directly in the Safe Apps list card, creating a valid link to get to the Safe App landing page.

[Figma Designs](https://www.figma.com/file/v56CKWh6Yp60cSsZ71URB0/dApp-sharing-functionality?node-id=1%3A967)

## How this PR fixes it

Added a new button to copy the Share Safe App url to the clipboard:

```
https://{{BASE_URL}}/app/share/safe-app?appUrl={{SAFE_APP_URL}}&chainId={{CHAIN_ID}}
```

### Moved `<SnackbarProvider />` component to `/src/components/Providers/index.tsx`

To be able to test that the Snackbar is showed, I moved our `<SnackbarProvider />` component from `src/components/App/index.tsx` to `/src/components/Providers/index.tsx` (where all our providers are defined)

Now we can check if a Snackbar is showed in our unit tests:
```
     [...]

      // snackbar is not present
      expect(screen.queryByText('Safe App url copied to clipboard!')).not.toBeInTheDocument()

      // we click on the Share Safe App Button
      fireEvent.click(compoundAppShareBtn)

     [...]

      // we show a snackbar
      expect(screen.getByText('Safe App url copied to clipboard!')).toBeInTheDocument()
```

## How to test it

1. Go to the Safe Apps Section.
2. Hover a Safe App Card.
3. Click on Share Icon.

## Analytics changes

TBD

## Screenshots

![Captura de pantalla 2022-04-11 a las 14 53 55](https://user-images.githubusercontent.com/26763673/162744870-0a34027a-4737-49fe-9d94-eda44d521d9a.png)
![Captura de pantalla 2022-04-11 a las 14 54 00](https://user-images.githubusercontent.com/26763673/162744874-c7fd1b36-ae4a-4f14-bdbc-7bdee167e189.png)
