### PR TITLE
fix: generalise currency formatting

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -18,7 +18,7 @@ import { currentCurrencySelector } from 'src/logic/currencyValues/store/selector
 import Modal from 'src/components/Modal'
 import SendModal from 'src/routes/safe/components/Balances/SendModal'
 import useSafeActions from 'src/logic/safe/hooks/useSafeActions'
-import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
+import { formatCurrency } from 'src/logic/tokens/utils/formatAmount'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 import ReceiveModal from './ReceiveModal'
 import { useSidebarItems } from 'src/components/AppLayout/Sidebar/useSidebarItems'
@@ -61,9 +61,7 @@ const App: React.FC = ({ children }) => {
   useAddressBookSync()
 
   const sendFunds = safeActionsState.sendFunds
-  const formattedTotalBalance = currentSafeBalance ? formatAmount(currentSafeBalance.toString()) : ''
-  const balance =
-    !!formattedTotalBalance && !!currentCurrency ? `${formattedTotalBalance} ${currentCurrency}` : undefined
+  const balance = formatCurrency(currentSafeBalance.toString(), currentCurrency)
 
   const onReceiveShow = () => onShow('Receive')
   const onReceiveHide = () => onHide('Receive')

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -18,7 +18,7 @@ import { currentCurrencySelector } from 'src/logic/currencyValues/store/selector
 import Modal from 'src/components/Modal'
 import SendModal from 'src/routes/safe/components/Balances/SendModal'
 import useSafeActions from 'src/logic/safe/hooks/useSafeActions'
-import { formatAmountInUsFormat } from 'src/logic/tokens/utils/formatAmount'
+import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
 import { grantedSelector } from 'src/routes/safe/container/selector'
 import ReceiveModal from './ReceiveModal'
 import { useSidebarItems } from 'src/components/AppLayout/Sidebar/useSidebarItems'
@@ -61,7 +61,7 @@ const App: React.FC = ({ children }) => {
   useAddressBookSync()
 
   const sendFunds = safeActionsState.sendFunds
-  const formattedTotalBalance = currentSafeBalance ? formatAmountInUsFormat(currentSafeBalance.toString()) : ''
+  const formattedTotalBalance = currentSafeBalance ? formatAmount(currentSafeBalance.toString()) : ''
   const balance =
     !!formattedTotalBalance && !!currentCurrency ? `${formattedTotalBalance} ${currentCurrency}` : undefined
 

--- a/src/logic/tokens/utils/__tests__/formatAmount.test.ts
+++ b/src/logic/tokens/utils/__tests__/formatAmount.test.ts
@@ -1,4 +1,4 @@
-import { formatAmount, formatAmountInUsFormat } from 'src/logic/tokens/utils/formatAmount'
+import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
 
 describe('formatAmount', () => {
   it('Given 0 returns 0', () => {
@@ -101,75 +101,6 @@ describe('formatAmount', () => {
 
     // when
     const result = formatAmount(input.toString())
-
-    // then
-    expect(result).toBe(expectedResult)
-  })
-})
-
-describe('FormatsAmountsInUsFormat', () => {
-  it('Given 0 returns 0.00', () => {
-    // given
-    const input = 0
-    const expectedResult = '0.00'
-
-    // when
-    const result = formatAmountInUsFormat(input.toString())
-
-    // then
-    expect(result).toBe(expectedResult)
-  })
-  it('Given 1 returns 1.00', () => {
-    // given
-    const input = 1
-    const expectedResult = '1.00'
-
-    // when
-    const result = formatAmountInUsFormat(input.toString())
-
-    // then
-    expect(result).toBe(expectedResult)
-  })
-  it('Given a number in format XXXXX.XX returns a number of format XXX,XXX.XX', () => {
-    // given
-    const input = 311137.3
-    const expectedResult = '311,137.30'
-
-    // when
-    const result = formatAmountInUsFormat(input.toString())
-
-    // then
-    expect(result).toBe(expectedResult)
-  })
-  it('Given a number in format XXXXX.XXX returns a number of format XX,XXX.XXX', () => {
-    // given
-    const input = 19797.899
-    const expectedResult = '19,797.899'
-
-    // when
-    const result = formatAmountInUsFormat(input.toString())
-
-    // then
-    expect(result).toBe(expectedResult)
-  })
-  it('Given a number in format XXXXXXXX.XXX returns a number of format XX,XXX,XXX.XXX', () => {
-    // given
-    const input = 19797899.479
-    const expectedResult = '19,797,899.479'
-
-    // when
-    const result = formatAmountInUsFormat(input.toString())
-
-    // then
-    expect(result).toBe(expectedResult)
-  })
-  it('Given a number in format XXXXXXXXXXX.XXX returns a number of format XX,XXX,XXX,XXX.XXX', () => {
-    // given
-    const input = 19797899479.999
-    const expectedResult = '19,797,899,479.999'
-
-    // when
-    const result = formatAmountInUsFormat(input.toString())
 
     // then
     expect(result).toBe(expectedResult)

--- a/src/logic/tokens/utils/__tests__/formatAmount.test.ts
+++ b/src/logic/tokens/utils/__tests__/formatAmount.test.ts
@@ -94,10 +94,10 @@ describe('formatAmount', () => {
     // then
     expect(result).toBe(expectedResult)
   })
-  it('Given number > 10 ** 15 returns > 10,000T', () => {
+  it('Given number > 10 ** 15 returns > 1000T', () => {
     // given
-    const input = 10e15
-    const expectedResult = '> 10,000T'
+    const input = 10 ** 15 * 2
+    const expectedResult = '> 1000T'
 
     // when
     const result = formatAmount(input.toString())

--- a/src/logic/tokens/utils/__tests__/formatAmount.test.ts
+++ b/src/logic/tokens/utils/__tests__/formatAmount.test.ts
@@ -1,4 +1,4 @@
-import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
+import { formatAmount, formatCurrency } from 'src/logic/tokens/utils/formatAmount'
 
 describe('formatAmount', () => {
   it('Given 0 returns 0', () => {
@@ -104,5 +104,83 @@ describe('formatAmount', () => {
 
     // then
     expect(result).toBe(expectedResult)
+  })
+})
+
+describe('formatCurrency', () => {
+  it('Given 0 returns 0.00', () => {
+    // given
+    const input = 0
+    const expectedResult = '0.00 EUR'
+
+    // when
+    const result = formatCurrency(input.toString(), 'EUR')
+
+    // then
+    expect(result).toBe(expectedResult)
+  })
+  it('Given 1 returns 1.00', () => {
+    // given
+    const input = 1
+    const expectedResult = '1.00 EUR'
+
+    // when
+    const result = formatCurrency(input.toString(), 'EUR')
+
+    // then
+    expect(result).toBe(expectedResult)
+  })
+  it('Given a number in format XXXXX.XX returns a number of format XXX,XXX.XX', () => {
+    // given
+    const input = 311137.3
+    const expectedResult = '311,137.30 EUR'
+
+    // when
+    const result = formatCurrency(input.toString(), 'EUR')
+
+    // then
+    expect(result).toBe(expectedResult)
+  })
+  it('Given a number in format XXXXX.XXX returns a number of format XX,XXX.XXX', () => {
+    // given
+    const input = 19797.899
+    const expectedResult = '19,797.899 EUR'
+
+    // when
+    const result = formatCurrency(input.toString(), 'EUR')
+
+    // then
+    expect(result).toBe(expectedResult)
+  })
+  it('Given a number in format XXXXXXXX.XXX returns a number of format XX,XXX,XXX.XXX', () => {
+    // given
+    const input = 19797899.479
+    const expectedResult = '19,797,899.479 EUR'
+
+    // when
+    const result = formatCurrency(input.toString(), 'EUR')
+
+    // then
+    expect(result).toBe(expectedResult)
+  })
+  it('Given a number in format XXXXXXXXXXX.XXX returns a number of format XX,XXX,XXX,XXX.XXX', () => {
+    // given
+    const input = 19797899479.999
+    const expectedResult = '19,797,899,479.999 EUR'
+
+    // when
+    const result = formatCurrency(input.toString(), 'EUR')
+
+    // then
+    expect(result).toBe(expectedResult)
+  })
+  it('Accepts varied currencies', () => {
+    expect(formatCurrency('10', 'USD')).toBe('10.00 USD')
+    expect(formatCurrency('10', 'GBP')).toBe('10.00 GBP')
+  })
+
+  it('Accepts crypto currencies', () => {
+    expect(formatCurrency('10', 'xDai')).toBe('10.00 xDai')
+    expect(formatCurrency('10', 'GNO')).toBe('10.00 GNO')
   })
 })

--- a/src/logic/tokens/utils/__tests__/formatAmount.test.ts
+++ b/src/logic/tokens/utils/__tests__/formatAmount.test.ts
@@ -1,5 +1,7 @@
 import { formatAmount, formatCurrency } from 'src/logic/tokens/utils/formatAmount'
 
+// The test environment defaults Intl.NumberFormat to en-US as Node doesn't ship with every locale
+// hence the tests hardcoding en-US formatting but the browser will format correctly
 describe('formatAmount', () => {
   it('Given 0 returns 0', () => {
     // given

--- a/src/logic/tokens/utils/__tests__/formatAmount.test.ts
+++ b/src/logic/tokens/utils/__tests__/formatAmount.test.ts
@@ -94,10 +94,10 @@ describe('formatAmount', () => {
     // then
     expect(result).toBe(expectedResult)
   })
-  it('Given number > 10 ** 15 returns > 1000T', () => {
+  it('Given number > 10 ** 15 returns > 10,000T', () => {
     // given
-    const input = 10 ** 15 * 2
-    const expectedResult = '> 1000T'
+    const input = 10e15
+    const expectedResult = '> 10,000T'
 
     // when
     const result = formatAmount(input.toString())

--- a/src/logic/tokens/utils/formatAmount.ts
+++ b/src/logic/tokens/utils/formatAmount.ts
@@ -44,12 +44,12 @@ export const formatAmount = (number: string): string => {
   return numberFloat
 }
 
-export const formatCurrency = (amount: string, currencySelected: string): string => {
-  const formatter = new Intl.NumberFormat(LOCALE, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 8,
-  })
+const currencyFormatter = new Intl.NumberFormat(LOCALE, {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 8,
+})
 
+export const formatCurrency = (amount: string, currencySelected: string): string => {
   const numberFloat = parseFloat(amount)
-  return `${formatter.format(numberFloat)} ${currencySelected}`
+  return `${currencyFormatter.format(numberFloat)} ${currencySelected}`
 }

--- a/src/logic/tokens/utils/formatAmount.ts
+++ b/src/logic/tokens/utils/formatAmount.ts
@@ -2,8 +2,8 @@
 // https://v8.dev/features/intl-numberformat
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat
 
-// Locale is an empty array because we want it to use user's locale
-const LOCALE = []
+// Locale is undefined because we want it to use user's locale
+const LOCALE = undefined
 
 const lt1kFormatter = new Intl.NumberFormat(LOCALE, { maximumFractionDigits: 5 })
 const lt10kFormatter = new Intl.NumberFormat(LOCALE, { maximumFractionDigits: 4 })

--- a/src/logic/tokens/utils/formatAmount.ts
+++ b/src/logic/tokens/utils/formatAmount.ts
@@ -39,11 +39,3 @@ export const formatAmount = (number: string): string => {
 
   return numberFloat
 }
-
-const options = { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 8 }
-const usNumberFormatter = new Intl.NumberFormat('en-US', options)
-
-export const formatAmountInUsFormat = (amount: string): string => {
-  const numberFloat: number = parseFloat(amount)
-  return usNumberFormatter.format(numberFloat).replace('$', '')
-}

--- a/src/logic/tokens/utils/formatAmount.ts
+++ b/src/logic/tokens/utils/formatAmount.ts
@@ -34,11 +34,11 @@ export const formatAmount = (number: string): string => {
     numberFloat = lt10mFormatter.format(numberFloat)
   } else if (numberFloat < 100_000_000) {
     numberFloat = lt100mFormatter.format(numberFloat)
-  } else if (numberFloat < 10e15) {
+  } else if (numberFloat < 10 ** 15) {
     numberFloat = lt1000tFormatter.format(numberFloat)
   } else {
-    // Localized '> 10,000T'
-    numberFloat = `> ${gt1000tFormatter.format(10e15)}`
+    // Localized '> 1000T'
+    numberFloat = `> ${gt1000tFormatter.format(10 ** 15)}`
   }
 
   return numberFloat

--- a/src/logic/tokens/utils/formatAmount.ts
+++ b/src/logic/tokens/utils/formatAmount.ts
@@ -3,14 +3,17 @@
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat
 
 // Locale is an empty array because we want it to use user's locale
-const lt1kFormatter = new Intl.NumberFormat([], { maximumFractionDigits: 5 })
-const lt10kFormatter = new Intl.NumberFormat([], { maximumFractionDigits: 4 })
-const lt100kFormatter = new Intl.NumberFormat([], { maximumFractionDigits: 3 })
-const lt1mFormatter = new Intl.NumberFormat([], { maximumFractionDigits: 2 })
-const lt10mFormatter = new Intl.NumberFormat([], { maximumFractionDigits: 1 })
-const lt100mFormatter = new Intl.NumberFormat([], { maximumFractionDigits: 0 })
+const LOCALE = []
+
+const lt1kFormatter = new Intl.NumberFormat(LOCALE, { maximumFractionDigits: 5 })
+const lt10kFormatter = new Intl.NumberFormat(LOCALE, { maximumFractionDigits: 4 })
+const lt100kFormatter = new Intl.NumberFormat(LOCALE, { maximumFractionDigits: 3 })
+const lt1mFormatter = new Intl.NumberFormat(LOCALE, { maximumFractionDigits: 2 })
+const lt10mFormatter = new Intl.NumberFormat(LOCALE, { maximumFractionDigits: 1 })
+const lt100mFormatter = new Intl.NumberFormat(LOCALE, { maximumFractionDigits: 0 })
 // same format for billions and trillions
-const lt1000tFormatter = new Intl.NumberFormat([], { maximumFractionDigits: 3, notation: 'compact' } as any)
+const lt1000tFormatter = new Intl.NumberFormat(LOCALE, { maximumFractionDigits: 3, notation: 'compact' })
+const gt1000tFormatter = new Intl.NumberFormat(LOCALE, { notation: 'compact' })
 
 export const formatAmount = (number: string): string => {
   let numberFloat: number | string = parseFloat(number)
@@ -18,24 +21,35 @@ export const formatAmount = (number: string): string => {
   if (numberFloat === 0) {
     numberFloat = '0'
   } else if (numberFloat < 0.001) {
-    numberFloat = '< 0.001'
-  } else if (numberFloat < 1000) {
+    numberFloat = `< ${lt1kFormatter.format(0.001)}`
+  } else if (numberFloat < 1_000) {
     numberFloat = lt1kFormatter.format(numberFloat)
-  } else if (numberFloat < 10000) {
+  } else if (numberFloat < 10_000) {
     numberFloat = lt10kFormatter.format(numberFloat)
-  } else if (numberFloat < 100000) {
+  } else if (numberFloat < 100_000) {
     numberFloat = lt100kFormatter.format(numberFloat)
-  } else if (numberFloat < 1000000) {
+  } else if (numberFloat < 1_000_000) {
     numberFloat = lt1mFormatter.format(numberFloat)
-  } else if (numberFloat < 10000000) {
+  } else if (numberFloat < 10_000_000) {
     numberFloat = lt10mFormatter.format(numberFloat)
-  } else if (numberFloat < 100000000) {
+  } else if (numberFloat < 100_000_000) {
     numberFloat = lt100mFormatter.format(numberFloat)
-  } else if (numberFloat < 10 ** 15) {
+  } else if (numberFloat < 10e15) {
     numberFloat = lt1000tFormatter.format(numberFloat)
   } else {
-    numberFloat = '> 1000T'
+    // Localized '> 10,000T'
+    numberFloat = `> ${gt1000tFormatter.format(10e15)}`
   }
 
   return numberFloat
+}
+
+export const formatCurrency = (amount: string, currencySelected: string): string => {
+  const formatter = new Intl.NumberFormat(LOCALE, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 8,
+  })
+
+  const numberFloat = parseFloat(amount)
+  return `${formatter.format(numberFloat)} ${currencySelected}`
 }

--- a/src/routes/safe/components/Balances/dataFetcher.ts
+++ b/src/routes/safe/components/Balances/dataFetcher.ts
@@ -1,18 +1,10 @@
 import { List } from 'immutable'
-import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
+import { formatCurrency } from 'src/logic/tokens/utils/formatAmount'
 import { TableColumn } from 'src/components/Table/types.d'
 import { Token } from 'src/logic/tokens/store/model/token'
 export const BALANCE_TABLE_ASSET_ID = 'asset'
 export const BALANCE_TABLE_BALANCE_ID = 'balance'
 export const BALANCE_TABLE_VALUE_ID = 'value'
-
-const getTokenPriceInCurrency = (balance: string, currencySelected?: string): string => {
-  if (!currencySelected) {
-    return Number('').toFixed(2)
-  }
-  return `${formatAmount(Number(balance).toFixed(2))} ${currencySelected}`
-}
-
 export interface BalanceData {
   asset: { name: string; logoUri: string; address: string; symbol: string }
   assetOrder: string
@@ -22,7 +14,7 @@ export interface BalanceData {
   valueOrder: number
 }
 
-export const getBalanceData = (safeTokens: List<Token>, currencySelected?: string): List<BalanceData> => {
+export const getBalanceData = (safeTokens: List<Token>, currencySelected: string): List<BalanceData> => {
   return safeTokens.map((token) => {
     const { tokenBalance, fiatBalance } = token.balance
 
@@ -34,9 +26,9 @@ export const getBalanceData = (safeTokens: List<Token>, currencySelected?: strin
         symbol: token.symbol,
       },
       assetOrder: token.name,
-      [BALANCE_TABLE_BALANCE_ID]: `${formatAmount(tokenBalance?.toString() || '0')} ${token.symbol}`,
+      [BALANCE_TABLE_BALANCE_ID]: formatCurrency(tokenBalance?.toString() || '0', token.symbol),
       balanceOrder: Number(tokenBalance),
-      [BALANCE_TABLE_VALUE_ID]: getTokenPriceInCurrency(fiatBalance || '0', currencySelected),
+      [BALANCE_TABLE_VALUE_ID]: formatCurrency(fiatBalance?.toString() || '0', currencySelected),
       valueOrder: Number(tokenBalance),
     }
   })

--- a/src/routes/safe/components/Balances/dataFetcher.ts
+++ b/src/routes/safe/components/Balances/dataFetcher.ts
@@ -1,5 +1,5 @@
 import { List } from 'immutable'
-import { formatAmountInUsFormat } from 'src/logic/tokens/utils/formatAmount'
+import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
 import { TableColumn } from 'src/components/Table/types.d'
 import { Token } from 'src/logic/tokens/store/model/token'
 export const BALANCE_TABLE_ASSET_ID = 'asset'
@@ -10,7 +10,7 @@ const getTokenPriceInCurrency = (balance: string, currencySelected?: string): st
   if (!currencySelected) {
     return Number('').toFixed(2)
   }
-  return `${formatAmountInUsFormat(Number(balance).toFixed(2))} ${currencySelected}`
+  return `${formatAmount(Number(balance).toFixed(2))} ${currencySelected}`
 }
 
 export interface BalanceData {
@@ -34,7 +34,7 @@ export const getBalanceData = (safeTokens: List<Token>, currencySelected?: strin
         symbol: token.symbol,
       },
       assetOrder: token.name,
-      [BALANCE_TABLE_BALANCE_ID]: `${formatAmountInUsFormat(tokenBalance?.toString() || '0')} ${token.symbol}`,
+      [BALANCE_TABLE_BALANCE_ID]: `${formatAmount(tokenBalance?.toString() || '0')} ${token.symbol}`,
       balanceOrder: Number(tokenBalance),
       [BALANCE_TABLE_VALUE_ID]: getTokenPriceInCurrency(fiatBalance || '0', currencySelected),
       valueOrder: Number(tokenBalance),


### PR DESCRIPTION
## What it solves
Resolves #3792

## How this PR fixes it
Some values were being formatted to US style by default. This function has been adjusted to simply format numberd and append the currency to the end.

## How to test it
Switch the browser locale between UK and EU (UK using comma thousand separators and full stop decimal separators and EU using the inverse) and observe the following:

- Balance is correctly formatted
- Transaction amount received and that listed in the transaction list also

## Screenshots
Taken from the reported transactions `/app/bnb:0x01859368761983ce07c9610BA1C3B2FBa60cae31/transactions/ethereum_0x01859368761983ce07c9610BA1C3B2FBa60cae31_0xa4cdc401a1e67447867559c04dc784c56bbb44c70c2916b281c5d77028528852_0x9e2afd8eb251cf4b`:

![image](https://user-images.githubusercontent.com/20442784/164026374-a1799910-8a4d-4bfc-84cc-004ee744fb02.png)