### PR TITLE
fix: hardware wallet console errors

### DIFF
--- a/src/logic/wallets/__tests__/network.test.ts
+++ b/src/logic/wallets/__tests__/network.test.ts
@@ -2,6 +2,7 @@ import { Wallet } from 'bnc-onboard/dist/src/interfaces'
 
 import { ChainId } from 'src/config/chain.d'
 import { switchNetwork, shouldSwitchNetwork } from 'src/logic/wallets/utils/network'
+import { WALLET_PROVIDER } from '../getWeb3'
 
 class CodedError extends Error {
   public code: number
@@ -83,6 +84,25 @@ describe('src/logic/wallets/utils/network', () => {
       }
 
       expect(shouldSwitchNetwork(wallet as Wallet)).toBe(false)
+    })
+    it('should return false when it is a hardware wallet', () => {
+      expect(
+        shouldSwitchNetwork({
+          name: WALLET_PROVIDER.LEDGER,
+        } as Wallet),
+      ).toBe(false)
+
+      expect(
+        shouldSwitchNetwork({
+          name: WALLET_PROVIDER.TREZOR,
+        } as Wallet),
+      ).toBe(false)
+
+      expect(
+        shouldSwitchNetwork({
+          type: 'hardware',
+        } as Wallet),
+      ).toBe(false)
     })
     describe('should return true when networks mismatch', () => {
       it('for numeric `chainId`s', () => {

--- a/src/logic/wallets/utils/network.ts
+++ b/src/logic/wallets/utils/network.ts
@@ -6,6 +6,7 @@ import { getChainInfo, getExplorerUrl, getPublicRpcUrl, _getChainId } from 'src/
 import { ChainId } from 'src/config/chain.d'
 import { Errors, CodedException } from 'src/logic/exceptions/CodedException'
 import { isPairingModule } from 'src/logic/wallets/pairing/utils'
+import { isHardwareWallet } from '../getWeb3'
 
 const WALLET_ERRORS = {
   UNRECOGNIZED_CHAIN: 4902,
@@ -20,11 +21,9 @@ const WALLET_ERRORS = {
 const requestSwitch = async (wallet: Wallet, chainId: ChainId): Promise<void> => {
   // Note: This could support WC too
   if (isPairingModule(wallet.name)) {
-    if (wallet.provider) {
-      wallet.provider.wc.updateSession({ chainId: parseInt(chainId, 10), accounts: wallet.provider.wc.accounts })
-    }
+    wallet.provider?.wc.updateSession({ chainId: parseInt(chainId, 10), accounts: wallet.provider.wc.accounts })
   } else {
-    await wallet.provider.request({
+    await wallet.provider?.request({
       method: 'wallet_switchEthereumChain',
       params: [
         {
@@ -85,7 +84,7 @@ export const switchNetwork = async (wallet: Wallet, chainId: ChainId): Promise<v
 }
 
 export const shouldSwitchNetwork = (wallet: Wallet): boolean => {
-  if (!wallet.provider) {
+  if (!wallet.provider || isHardwareWallet(wallet)) {
     return false
   }
 


### PR DESCRIPTION
## What it solves
Resolves #3762

## How this PR fixes it
As hardware wallets cannot themselves change network, `shouldSwitchNetwork` now returns `false` when they are detected.

## How to test it
Open the wallet connection modal and choose Ledger/Trezor. Observe no error in the console.

## Screenshots

![hwwarning](https://user-images.githubusercontent.com/20442784/164219267-97cf10ce-2af0-4fc1-b153-522363ba3138.gif)