### PR TITLE
Fix: block custom JS in GTM

### DIFF
--- a/src/utils/__tests__/googleTagManager.test.tsx
+++ b/src/utils/__tests__/googleTagManager.test.tsx
@@ -117,6 +117,8 @@ describe('googleTagManager', () => {
         auth: 'auth123',
         preview: 'env-3',
         dataLayer: {
+          'gtm.allowlist': ['gaawc', 'gaawe'],
+          'gtm.blocklist': ['j', 'jsm', 'customScripts'],
           event: 'pageview',
           chainId: '4',
           page: '/',

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -86,6 +86,11 @@ export const loadGoogleTagManager = (): void => {
       event: GTM_EVENT.PAGEVIEW,
       chainId: _getChainId(),
       page,
+      // Allow only GA4 configuration and GA4 custom event tags
+      // @see https://developers.google.com/tag-platform/tag-manager/web/restrict
+      'gtm.allowlist': ['gaawc', 'gaawe'],
+      // Block JS variables and custom scripts
+      'gtm.blocklist': ['j', 'jsm', 'customScripts'],
     },
   })
 }


### PR DESCRIPTION
## What it solves
GTM by default allows custom JavaScript tags which is a security concern.

This PR blocks any tags other than GA4 tags.

https://developers.google.com/tag-platform/tag-manager/web/restrict

## How to test it

All of our events should continue working fine.
