### PR TITLE
fix: stricter linting across repo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,15 +16,24 @@ module.exports = {
     },
   },
   rules: {
+    // Errors:
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warn',
-    'react/prop-types': 'off',
-    'react/react-in-jsx-scope': 'off',
-    '@typescript-eslint/camelcase': 'off',
-    '@typescript-eslint/no-var-requires': 'off',
-    '@typescript-eslint/no-empty-function': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
+    'react-hooks/exhaustive-deps': 'error',
+    'react/no-danger': 'error', // Prevent usage of dangerous JSX props
+    'react/self-closing-comp': ['error', { component: true, html: true }],
+    'react/void-dom-elements-no-children': 'error', // No passing of children to void DOM elements
+    'react/jsx-boolean-value': 'error', // Boolean attributes notation in JSX
+    'react/jsx-key': 'error', // Missing iterators/collection literals keys
+    'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
     '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
+    // Disabled:
+    'react/react-in-jsx-scope': 'off', // React 17+ doesn't require the explicit import of React
+    '@typescript-eslint/no-empty-function': 'off', // Sometimes we use empty functions as context defaults
+    /**
+     * The following was added by legacy devs to suppress warnings
+     */
+    '@typescript-eslint/no-explicit-any': 'off',
+    'react/prop-types': 'off',
   },
   settings: {
     react: {

--- a/package.json
+++ b/package.json
@@ -44,15 +44,7 @@
     "cypress:run": "node ./scripts/cypress.js run"
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx}": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "public/**/*.ts": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "scripts/**/*.{js,jsx,ts,tsx}": [
+    "*.{js,jsx,ts,tsx}": [
       "eslint --fix",
       "prettier --write"
     ]


### PR DESCRIPTION
## What it solves
Lax linting/prettier

## How this PR fixes it
The whole project is now checked for lint and automatically prettified. The linting rules were made stricter.

We should ideally remove `'@typescript-eslint/no-explicit-any'` as well as enable the default React linter but this resurrected >100 warnings of non/false-typed code and typing this manually started to get out of hand. I have a local stash of this locally but it became quickly apparent that this would like cause bugs/require a full regression.

For now, the added rules and project-wide scanning should improve our committed code.

## How to test it

- Commit unformatted code and see it get automatically 'prettified'
- Attempt to commit code that goes against our rules and observe a warning that prevents pushing
