### PR TITLE
fix: show estimation warnings on Safes that require `safeTxGas`

### DIFF
--- a/src/logic/hooks/__tests__/useEstimateSafeTxGas.test.ts
+++ b/src/logic/hooks/__tests__/useEstimateSafeTxGas.test.ts
@@ -22,28 +22,7 @@ const actResolve = async (callback: () => unknown): Promise<void> => {
 }
 
 describe('useEstimateSafeTxGas', () => {
-  it(`should return 0 if the Safe does not require safeTxGas (is an older version)`, async () => {
-    jest.spyOn(safeTxGas, 'default').mockImplementation(() => false)
-    const spy = jest.spyOn(gas, 'estimateSafeTxGas')
-
-    await actResolve(() => {
-      const { result } = renderHook(() =>
-        useEstimateSafeTxGas({
-          txAmount: '',
-          txData: '',
-          txRecipient: '',
-          isCreation: true,
-          isRejectTx: false,
-        }),
-      )
-
-      expect(result.current.result).toBe('0')
-    })
-
-    expect(spy).toHaveBeenCalledTimes(0)
-  })
-  it(`should return 0 if it is not a tx creation`, async () => {
-    jest.spyOn(safeTxGas, 'default').mockImplementation(() => true)
+  it(`should return 0 if it is not a proposed transaction`, async () => {
     const spy = jest.spyOn(gas, 'estimateSafeTxGas')
 
     await actResolve(() => {
@@ -52,31 +31,10 @@ describe('useEstimateSafeTxGas', () => {
           txAmount: '',
           txData: '0x',
           txRecipient: '',
-          isCreation: false,
-          isRejectTx: false,
+          isExecution: false,
         }),
       )
 
-      expect(result.current.result).toBe('0')
-    })
-
-    expect(spy).toHaveBeenCalledTimes(0)
-  })
-
-  it(`should return 0 if it is a reject tx`, async () => {
-    jest.spyOn(safeTxGas, 'default').mockImplementation(() => true)
-    const spy = jest.spyOn(gas, 'estimateSafeTxGas')
-
-    await actResolve(() => {
-      const { result } = renderHook(() =>
-        useEstimateSafeTxGas({
-          txAmount: '',
-          txData: '0x',
-          txRecipient: '',
-          isCreation: false,
-          isRejectTx: true,
-        }),
-      )
       expect(result.current.result).toBe('0')
     })
 
@@ -84,7 +42,6 @@ describe('useEstimateSafeTxGas', () => {
   })
 
   it(`should return 0 if tx data is not passed`, async () => {
-    jest.spyOn(safeTxGas, 'default').mockImplementation(() => true)
     const spy = jest.spyOn(gas, 'estimateSafeTxGas')
 
     await actResolve(() => {
@@ -93,8 +50,7 @@ describe('useEstimateSafeTxGas', () => {
           txAmount: '',
           txData: '',
           txRecipient: '',
-          isCreation: true,
-          isRejectTx: false,
+          isExecution: true,
         }),
       )
 
@@ -104,27 +60,7 @@ describe('useEstimateSafeTxGas', () => {
     expect(spy).toHaveBeenCalledTimes(0)
   })
 
-  it(`calls estimateSafeTxGas if it is a tx creation`, async () => {
-    jest.spyOn(safeTxGas, 'default').mockImplementation(() => true)
-    const spy = jest.spyOn(gas, 'estimateSafeTxGas')
-
-    await actResolve(() => {
-      renderHook(() =>
-        useEstimateSafeTxGas({
-          txAmount: '',
-          txData: '0x',
-          txRecipient: '',
-          isCreation: true,
-          isRejectTx: false,
-        }),
-      )
-    })
-
-    expect(spy).toHaveBeenCalledTimes(1)
-  })
-
   it(`return the error object and 0 if estimateSafeTxGas throws`, async () => {
-    jest.spyOn(safeTxGas, 'default').mockImplementation(() => true)
     const spy = jest.spyOn(gas, 'estimateSafeTxGas').mockImplementation(() => {
       throw new Error('Estimation failed')
     })
@@ -135,8 +71,7 @@ describe('useEstimateSafeTxGas', () => {
           txAmount: '',
           txData: '0x',
           txRecipient: '',
-          isCreation: true,
-          isRejectTx: false,
+          isExecution: true,
         }),
       )
 

--- a/src/logic/hooks/useEstimateSafeTxGas.tsx
+++ b/src/logic/hooks/useEstimateSafeTxGas.tsx
@@ -5,11 +5,9 @@ import { useSelector } from 'react-redux'
 import { estimateSafeTxGas } from 'src/logic/safe/transactions/gas'
 import { currentSafe } from 'src/logic/safe/store/selectors'
 import useAsync from 'src/logic/hooks/useAsync'
-import useSafeTxGas from 'src/routes/safe/components/Transactions/helpers/useSafeTxGas'
 
 type UseEstimateSafeTxGasProps = {
-  isCreation: boolean
-  isRejectTx: boolean
+  isExecution: boolean
   txData: string
   txRecipient: string
   txAmount: string
@@ -17,8 +15,7 @@ type UseEstimateSafeTxGasProps = {
 }
 
 export const useEstimateSafeTxGas = ({
-  isCreation,
-  isRejectTx,
+  isExecution,
   txData,
   txRecipient,
   txAmount,
@@ -26,12 +23,9 @@ export const useEstimateSafeTxGas = ({
 }: UseEstimateSafeTxGasProps): { error: Error | undefined; result: string } => {
   const defaultEstimation = '0'
   const { address: safeAddress, currentVersion: safeVersion } = useSelector(currentSafe)
-  const needSafeTxGas = useSafeTxGas()
 
   const requestSafeTxGas = useCallback((): Promise<string> => {
-    if (!isCreation || isRejectTx || !txData || !needSafeTxGas) {
-      return Promise.resolve(defaultEstimation)
-    }
+    if (!isExecution || !txData) return Promise.resolve(defaultEstimation)
 
     return estimateSafeTxGas(
       {
@@ -43,7 +37,7 @@ export const useEstimateSafeTxGas = ({
       },
       safeVersion,
     )
-  }, [isCreation, isRejectTx, operation, safeAddress, safeVersion, txAmount, txData, txRecipient, needSafeTxGas])
+  }, [isExecution, operation, safeAddress, safeVersion, txAmount, txData, txRecipient])
 
   const { result, error } = useAsync<string>(requestSafeTxGas)
 

--- a/src/logic/hooks/useEstimateSafeTxGas.tsx
+++ b/src/logic/hooks/useEstimateSafeTxGas.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux'
 import { estimateSafeTxGas } from 'src/logic/safe/transactions/gas'
 import { currentSafe } from 'src/logic/safe/store/selectors'
 import useAsync from 'src/logic/hooks/useAsync'
+import useSafeTxGas from 'src/routes/safe/components/Transactions/helpers/useSafeTxGas'
 
 type UseEstimateSafeTxGasProps = {
   isCreation: boolean
@@ -22,12 +23,15 @@ export const useEstimateSafeTxGas = ({
   txRecipient,
   txAmount,
   operation,
-}: UseEstimateSafeTxGasProps): string => {
+}: UseEstimateSafeTxGasProps): { error: Error | undefined; result: string } => {
   const defaultEstimation = '0'
   const { address: safeAddress, currentVersion: safeVersion } = useSelector(currentSafe)
+  const needSafeTxGas = useSafeTxGas()
 
   const requestSafeTxGas = useCallback((): Promise<string> => {
-    if (!isCreation || isRejectTx || !txData) return Promise.resolve(defaultEstimation)
+    if (!isCreation || isRejectTx || !txData || !needSafeTxGas) {
+      return Promise.resolve(defaultEstimation)
+    }
 
     return estimateSafeTxGas(
       {
@@ -39,9 +43,9 @@ export const useEstimateSafeTxGas = ({
       },
       safeVersion,
     )
-  }, [isCreation, isRejectTx, operation, safeAddress, safeVersion, txAmount, txData, txRecipient])
+  }, [isCreation, isRejectTx, operation, safeAddress, safeVersion, txAmount, txData, txRecipient, needSafeTxGas])
 
-  const { result } = useAsync<string>(requestSafeTxGas)
+  const { result, error } = useAsync<string>(requestSafeTxGas)
 
-  return result || defaultEstimation
+  return { result: result || defaultEstimation, error }
 }

--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -118,13 +118,13 @@ export const TxModalWrapper = ({
   const approvalAndExecution = isApproveAndExecute(Number(threshold), confirmationsLen, txType, preApprovingOwner)
 
   const { result: safeTxGasEstimation, error: safeTxGasError } = useEstimateSafeTxGas({
-    isCreation,
-    isRejectTx,
+    isExecution: doExecute,
     txData,
     txRecipient: txTo || safeAddress,
     txAmount: txValue,
     operation,
   })
+
   if (safeTxGas == null) safeTxGas = safeTxGasEstimation
 
   const { gasCostFormatted, gasPriceFormatted, gasMaxPrioFeeFormatted, gasLimit, txEstimationExecutionStatus } =

--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -117,7 +117,7 @@ export const TxModalWrapper = ({
 
   const approvalAndExecution = isApproveAndExecute(Number(threshold), confirmationsLen, txType, preApprovingOwner)
 
-  const safeTxGasEstimation = useEstimateSafeTxGas({
+  const { result: safeTxGasEstimation, error: safeTxGasError } = useEstimateSafeTxGas({
     isCreation,
     isRejectTx,
     txData,
@@ -235,7 +235,7 @@ export const TxModalWrapper = ({
               isExecution={doExecute}
               isRejection={isRejectTx}
               safeNonce={txParameters.safeNonce}
-              txEstimationExecutionStatus={txEstimationExecutionStatus}
+              txEstimationExecutionStatus={safeTxGasError ? EstimationStatus.FAILURE : txEstimationExecutionStatus}
             />
           )}
 


### PR DESCRIPTION
## What it solves
Resolves #3708

## How this PR fixes it
Errors thrown by `useEstimateSafeTxGas` are now taken into account when (not) showing an estimation failure on older Safes

## How to test it
- Open a Safe that requires `safeTxGas`, i.e. 1.1.1
- Attempt to create an invalid `changeThreshold` transaction
- Observe the estimation warning

## Screenshots
![1 1 1](https://user-images.githubusercontent.com/20442784/165111551-4374039b-de40-45f2-8d2e-5b82009a2af5.gif)