### PR TITLE
refactor: use the prefered local storage module in safe cretion

### DIFF
--- a/src/routes/CreateSafePage/CreateSafePage.test.tsx
+++ b/src/routes/CreateSafePage/CreateSafePage.test.tsx
@@ -41,19 +41,12 @@ describe('<CreateSafePage>', () => {
   it('renders CreateSafePage Form', async () => {
     render(<CreateSafePage />)
 
-    // we show a loader
-    expect(screen.getByTestId('create-safe-loader')).toBeInTheDocument()
-
-    // after that we show the form
-    await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
     await waitFor(() => expect(screen.getByTestId('create-safe-form')).toBeInTheDocument())
   })
 
   describe('Step 1: Connect wallet & select network', () => {
     it('Shows Connect Wallet Button if No wallet is connected', async () => {
       render(<CreateSafePage />)
-
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
       await waitFor(() => expect(screen.getByTestId('heading-connect-btn')).toBeInTheDocument())
     })
@@ -189,11 +182,14 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      expect(screen.getByText('Continue')).toBeInTheDocument()
+
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
 
-      await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
+      expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument()
     })
   })
   describe('Step 2: Safe Name', () => {
@@ -209,8 +205,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -230,8 +227,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -253,8 +251,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -278,8 +277,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -307,8 +307,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -345,8 +346,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -401,8 +403,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -445,8 +448,8 @@ describe('<CreateSafePage>', () => {
 
       render(<CreateSafePage />, customState)
 
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
-
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -474,8 +477,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -506,8 +510,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -550,8 +555,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -598,8 +604,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -656,8 +663,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -711,8 +719,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 
@@ -771,8 +780,9 @@ describe('<CreateSafePage>', () => {
       }
 
       render(<CreateSafePage />, customState)
-      await waitForElementToBeRemoved(() => screen.getByTestId('create-safe-loader'))
 
+      const continueButton = screen.getByText('Continue').parentElement as HTMLButtonElement
+      await waitFor(() => !continueButton.disabled)
       fireEvent.click(screen.getByText('Continue'))
       await waitFor(() => expect(screen.getByTestId('create-safe-name-step')).toBeInTheDocument())
 

--- a/src/routes/CreateSafePage/CreateSafePage.tsx
+++ b/src/routes/CreateSafePage/CreateSafePage.tsx
@@ -73,7 +73,7 @@ function CreateSafePage(): ReactElement {
       label: newSafeFormValues[FIELD_NEW_SAFE_THRESHOLD],
     })
 
-    local.setItem(SAFE_PENDING_CREATION_STORAGE_KEY, { ...newSafeFormValues })
+    local.setItem(SAFE_PENDING_CREATION_STORAGE_KEY, newSafeFormValues)
     setSafePendingToBeCreated(newSafeFormValues)
   }
 

--- a/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
+++ b/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
@@ -10,7 +10,7 @@ import { getSafeDeploymentTransaction } from 'src/logic/contracts/safeContracts'
 import { txMonitor } from 'src/logic/safe/transactions/txMonitor'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 import { SafeDeployment } from 'src/routes/opening'
-import { loadFromStorage, removeFromStorage, saveToStorage } from 'src/utils/storage'
+import local from 'src/utils/storage/local'
 import { addOrUpdateSafe } from 'src/logic/safe/store/actions/addOrUpdateSafe'
 import {
   SAFE_PENDING_CREATION_STORAGE_KEY,
@@ -91,7 +91,7 @@ const parseError = (err: Error): Error => {
 }
 
 const getSavedSafeCreation = (): CreateSafeFormValues | void => {
-  return loadFromStorage<CreateSafeFormValues>(SAFE_PENDING_CREATION_STORAGE_KEY)
+  return local.getItem<CreateSafeFormValues>(SAFE_PENDING_CREATION_STORAGE_KEY)
 }
 
 const loadSavedDataOrLeave = (): CreateSafeFormValues | void => {
@@ -130,7 +130,7 @@ const createNewSafe = (userAddress: string, onHash: (hash: string) => void): Pro
       .once('transactionHash', (txHash) => {
         onHash(txHash)
 
-        saveToStorage(SAFE_PENDING_CREATION_STORAGE_KEY, {
+        local.setItem(SAFE_PENDING_CREATION_STORAGE_KEY, {
           ...safeCreationFormValues,
           [FIELD_NEW_SAFE_PROXY_SALT]: safeCreationSalt,
           [FIELD_NEW_SAFE_CREATION_TX_HASH]: txHash,
@@ -256,7 +256,7 @@ function SafeCreationProcess(): ReactElement {
 
     // Clear the previous tx hash
     setSafeCreationTxHash(undefined)
-    saveToStorage(SAFE_PENDING_CREATION_STORAGE_KEY, {
+    local.setItem(SAFE_PENDING_CREATION_STORAGE_KEY, {
       ...safeCreationFormValues,
       safeCreationTxHash: undefined,
     })
@@ -265,12 +265,12 @@ function SafeCreationProcess(): ReactElement {
   }
 
   const onCancel = () => {
-    removeFromStorage(SAFE_PENDING_CREATION_STORAGE_KEY)
+    local.removeItem(SAFE_PENDING_CREATION_STORAGE_KEY)
     goToWelcomePage()
   }
 
   function onClickModalButton() {
-    removeFromStorage(SAFE_PENDING_CREATION_STORAGE_KEY)
+    local.removeItem(SAFE_PENDING_CREATION_STORAGE_KEY)
 
     const { safeName, safeCreationTxHash, safeAddress } = modalData
     history.push({


### PR DESCRIPTION
## What it solves
Uses the preferred LS module in the Safe creation flow
Fixes a leftover `await Promise.resolve(...)` wrapper around loading from local storage

## How to test it
Local Storage key should be
_SAFE__NEW_SAFE_PENDING_CREATION_STORAGE_KEY_
instead of
__immortal|v2_RINKEBY__NEW_SAFE_PENDING_CREATION_STORAGE_KEY_
