### PR TITLE
fix: Show safe thresholds for added safes in sidebar

### DIFF
--- a/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
+++ b/src/components/AppLayout/Sidebar/SafeHeader/index.tsx
@@ -32,6 +32,8 @@ import Track from 'src/components/Track'
 import { OVERVIEW_EVENTS } from 'src/utils/events/overview'
 import Threshold from 'src/components/AppLayout/Sidebar/Threshold'
 import { trackEvent } from 'src/utils/googleTagManager'
+import { Box } from '@material-ui/core'
+import { currentSafe } from 'src/logic/safe/store/selectors'
 
 export const TOGGLE_SIDEBAR_BTN_TESTID = 'TOGGLE_SIDEBAR_BTN'
 
@@ -206,6 +208,7 @@ const SafeHeader = ({
   onReceiveClick,
   onNewTransactionClick,
 }: Props): React.ReactElement => {
+  const { owners, threshold } = useSelector(currentSafe)
   const copyChainPrefix = useSelector(copyShortNameSelector)
   const shortName = extractShortChainName()
 
@@ -241,8 +244,10 @@ const SafeHeader = ({
       <Container>
         {/* Identicon */}
         <IdenticonContainer>
-          <Threshold />
-          <Identicon address={address} size="lg" />
+          <Box position="relative">
+            <Threshold threshold={threshold} owners={owners.length} />
+            <Identicon address={address} size="lg" />
+          </Box>
           <ToggleSafeListButton onClick={onToggleSafeList} data-testid={TOGGLE_SIDEBAR_BTN_TESTID}>
             <StyledIcon size="md" type="circleDropdown" />
           </ToggleSafeListButton>

--- a/src/components/AppLayout/Sidebar/Threshold/index.tsx
+++ b/src/components/AppLayout/Sidebar/Threshold/index.tsx
@@ -1,36 +1,36 @@
 import styled from 'styled-components'
-import { useSelector } from 'react-redux'
-import { primaryLite, primaryActive, smallFontSize } from 'src/theme/variables'
-import { currentSafe } from 'src/logic/safe/store/selectors'
 
-const Container = styled.div`
+import { primaryLite, primaryActive } from 'src/theme/variables'
+
+const Container = styled.div<{ size: number }>`
   background: ${primaryLite};
   color: ${primaryActive};
-  font-size: ${smallFontSize};
+  font-size: ${(p) => p.size}px;
   font-weight: bold;
   border-radius: 100%;
-  padding: 4px;
+  padding: 0.25em;
   position: absolute;
   z-index: 2;
-  top: -6px;
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 26px;
-  min-height: 26px;
-  box-sizing: border-box;
-  margin-left: -15px;
+  top: -8px;
+  left: -8px;
+  min-width: 1.5em;
+  min-height: 1.5em;
   display: flex;
   align-items: center;
+  justify-content: center;
   line-height: 1;
 `
 
-const Threshold = (): React.ReactElement | null => {
-  const { owners, threshold } = useSelector(currentSafe)
-  if (!threshold) return null
+type ThresholdProps = {
+  threshold: number
+  owners: number
+  size?: number
+}
 
+const Threshold = ({ threshold, owners, size = 12 }: ThresholdProps): React.ReactElement | null => {
   return (
-    <Container>
-      {threshold}/{owners.length}
+    <Container size={size}>
+      {threshold}/{owners}
     </Container>
   )
 }

--- a/src/components/Dashboard/Overview/Overview.tsx
+++ b/src/components/Dashboard/Overview/Overview.tsx
@@ -8,7 +8,7 @@ import { Skeleton } from '@material-ui/lab'
 
 import { currentSafeLoaded, currentSafeWithNames } from 'src/logic/safe/store/selectors'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
-import { primaryLite, primaryActive, smallFontSize, md, lg } from 'src/theme/variables'
+import { md, lg } from 'src/theme/variables'
 import NetworkLabel from 'src/components/NetworkLabel/NetworkLabel'
 import { nftLoadedSelector, nftTokensSelector } from 'src/logic/collectibles/store/selectors'
 import { Card, DashboardTitle } from 'src/components/Dashboard/styled'
@@ -17,26 +17,11 @@ import Button from 'src/components/layout/Button'
 import { generateSafeRoute, SAFE_ROUTES } from 'src/routes/routes'
 import { currentChainId } from 'src/logic/config/store/selectors'
 import { getChainById } from 'src/config'
+import Threshold from 'src/components/AppLayout/Sidebar/Threshold'
 
 const IdenticonContainer = styled.div`
   position: relative;
   margin-bottom: ${md};
-`
-
-const SafeThreshold = styled.div`
-  position: absolute;
-  left: -6px;
-  top: -6px;
-  background: ${primaryLite};
-  color: ${primaryActive};
-  font-size: ${smallFontSize};
-  font-weight: bold;
-  border-radius: 100%;
-  padding: 4px;
-  z-index: 2;
-  min-width: 24px;
-  min-height: 24px;
-  box-sizing: border-box;
 `
 
 const StyledText = styled(Text)`
@@ -117,9 +102,7 @@ const Overview = (): ReactElement => {
             <Grid container>
               <Grid item xs={12}>
                 <IdenticonContainer>
-                  <SafeThreshold>
-                    {threshold}/{owners.length}
-                  </SafeThreshold>
+                  <Threshold threshold={threshold} owners={owners.length} size={14} />
                   <Identicon address={address} size="xl" />
                 </IdenticonContainer>
                 <Box mb={2} overflow="hidden">

--- a/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
+++ b/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
@@ -5,7 +5,6 @@ import ListItem from '@material-ui/core/ListItem/ListItem'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction/ListItemSecondaryAction'
 import styled from 'styled-components'
 
-import { primaryLite, primaryActive } from 'src/theme/variables'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
@@ -23,6 +22,7 @@ import { currentChainId } from 'src/logic/config/store/selectors'
 import { ChainId } from 'src/config/chain.d'
 import { getChainById } from 'src/config'
 import { SafeOwner } from 'src/logic/safe/store/models/safe'
+import Threshold from 'src/components/AppLayout/Sidebar/Threshold'
 
 const StyledIcon = styled(Icon)<{ checked: boolean }>`
   ${({ checked }) => (checked ? { marginRight: '4px' } : { visibility: 'hidden', width: '28px' })}
@@ -58,26 +58,6 @@ const StyledPrefixedEthHashInfo = styled(PrefixedEthHashInfo)`
 
 const AddressContainer = styled.div`
   position: relative;
-`
-
-const Threshold = styled.div`
-  background: ${primaryLite};
-  color: ${primaryActive};
-  font-size: 10px;
-  font-weight: bold;
-  border-radius: 100%;
-  padding: 2px;
-  position: absolute;
-  z-index: 2;
-  top: -5px;
-  left: -5px;
-  min-width: 20px;
-  min-height: 20px;
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
 `
 
 type Props = {
@@ -143,11 +123,7 @@ const SafeListItem = ({
     <ListItem button onClick={handleOpenSafe} ref={safeRef}>
       <StyledIcon type="check" size="md" color="primary" checked={isCurrentSafe} />
       <AddressContainer>
-        {threshold && owners && (
-          <Threshold>
-            {threshold}/{owners.length}
-          </Threshold>
-        )}
+        {threshold && owners && <Threshold threshold={threshold} owners={owners.length} size={11} />}
         <StyledPrefixedEthHashInfo hash={address} name={safeName} shortName={shortName} showAvatar shortenHash={4} />
       </AddressContainer>
       <ListItemSecondaryAction>

--- a/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
+++ b/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
@@ -5,6 +5,7 @@ import ListItem from '@material-ui/core/ListItem/ListItem'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction/ListItemSecondaryAction'
 import styled from 'styled-components'
 
+import { primaryLite, primaryActive } from 'src/theme/variables'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
@@ -21,6 +22,7 @@ import {
 import { currentChainId } from 'src/logic/config/store/selectors'
 import { ChainId } from 'src/config/chain.d'
 import { getChainById } from 'src/config'
+import { SafeOwner } from 'src/logic/safe/store/models/safe'
 
 const StyledIcon = styled(Icon)<{ checked: boolean }>`
   ${({ checked }) => (checked ? { marginRight: '4px' } : { visibility: 'hidden', width: '28px' })}
@@ -54,6 +56,30 @@ const StyledPrefixedEthHashInfo = styled(PrefixedEthHashInfo)`
   }
 `
 
+const AddressContainer = styled.div`
+  position: relative;
+`
+
+const Threshold = styled.div`
+  background: ${primaryLite};
+  color: ${primaryActive};
+  font-size: 10px;
+  font-weight: bold;
+  border-radius: 100%;
+  padding: 2px;
+  position: absolute;
+  z-index: 2;
+  top: -5px;
+  left: -5px;
+  min-width: 20px;
+  min-height: 20px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+`
+
 type Props = {
   onSafeClick: () => void
   onNetworkSwitch?: () => void
@@ -62,6 +88,8 @@ type Props = {
   showAddSafeLink?: boolean
   networkId: ChainId
   shouldScrollToSafe?: boolean
+  threshold?: number
+  owners?: SafeOwner[]
 }
 
 const SafeListItem = ({
@@ -72,6 +100,8 @@ const SafeListItem = ({
   showAddSafeLink = false,
   networkId,
   shouldScrollToSafe = false,
+  threshold,
+  owners,
 }: Props): ReactElement => {
   const history = useHistory()
   const safeName = useSelector((state) => addressBookName(state, { address, chainId: networkId }))
@@ -112,7 +142,14 @@ const SafeListItem = ({
   return (
     <ListItem button onClick={handleOpenSafe} ref={safeRef}>
       <StyledIcon type="check" size="md" color="primary" checked={isCurrentSafe} />
-      <StyledPrefixedEthHashInfo hash={address} name={safeName} shortName={shortName} showAvatar shortenHash={4} />
+      <AddressContainer>
+        {threshold && owners && (
+          <Threshold>
+            {threshold}/{owners.length}
+          </Threshold>
+        )}
+        <StyledPrefixedEthHashInfo hash={address} name={safeName} shortName={shortName} showAvatar shortenHash={4} />
+      </AddressContainer>
       <ListItemSecondaryAction>
         {ethBalance ? (
           <StyledText size="lg">


### PR DESCRIPTION
## What it solves
Part of #3780 

## How this PR fixes it
We display the threshold and number of owners for added safes in the sidebar

## How to test it
1. Open the safe app
2. Open the sidebar drawer
3. Observe thresholds and number of owners for added safes

## Screenshots
![Screenshot 2022-04-26 at 11 38 43](https://user-images.githubusercontent.com/5880855/165271067-f2766b0f-33ff-4d4c-8d9f-d2b5a2fade31.png)

