### PR TITLE
Feat: prioritize pinned apps in the Dashboard

### DIFF
--- a/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/Dashboard/FeaturedApps/FeaturedApps.tsx
@@ -19,7 +19,6 @@ const StyledImage = styled.img`
 `
 
 const StyledLink = styled(Link)`
-  margin-top: 10px;
   text-decoration: none;
 `
 
@@ -44,21 +43,21 @@ export const FeaturedApps = (): ReactElement | null => {
             const appRoute = getSafeAppUrl(app.url, routesSlug)
             return (
               <Card key={app.id}>
-                <Grid container alignItems="center" spacing={3}>
-                  <Grid item xs={12} md={3}>
-                    <StyledImage src={app.iconUrl} alt={app.name} />
-                  </Grid>
-                  <Grid item xs={12} md={9}>
-                    <Box mb={1}>
-                      <Text size="xl">{app.description}</Text>
-                    </Box>
-                    <StyledLink to={appRoute}>
+                <StyledLink to={appRoute}>
+                  <Grid container alignItems="center" spacing={3}>
+                    <Grid item xs={12} md={3}>
+                      <StyledImage src={app.iconUrl} alt={app.name} />
+                    </Grid>
+                    <Grid item xs={12} md={9}>
+                      <Box mb={1.01}>
+                        <Text size="xl">{app.description}</Text>
+                      </Box>
                       <Text color="primary" size="lg" strong>
                         Use {app.name}
                       </Text>
-                    </StyledLink>
+                    </Grid>
                   </Grid>
-                </Grid>
+                </StyledLink>
               </Card>
             )
           })}

--- a/src/components/Dashboard/SafeApps/Grid.tsx
+++ b/src/components/Dashboard/SafeApps/Grid.tsx
@@ -4,7 +4,7 @@ import { Button } from '@gnosis.pm/safe-react-components'
 import { generatePath, Link } from 'react-router-dom'
 import Skeleton from '@material-ui/lab/Skeleton/Skeleton'
 import { Grid } from '@material-ui/core'
-import { sampleSize, uniq } from 'lodash'
+import { sampleSize, uniqBy } from 'lodash'
 
 import { screenSm, screenMd } from 'src/theme/variables'
 import { useAppList } from 'src/routes/safe/components/Apps/hooks/appList/useAppList'
@@ -76,7 +76,7 @@ const useRankedApps = (allApps: SafeApp[], pinnedSafeApps: SafeApp[], size: numb
     // Get random apps that are not ranked and not featured
     const randomApps = sampleSize(nonRankedApps, size - 1 - topRankedSafeApps.length)
 
-    const resultApps = uniq(topRankedSafeApps.concat(pinnedSafeApps).concat(randomApps))
+    const resultApps = uniqBy(topRankedSafeApps.concat(pinnedSafeApps).concat(randomApps), 'id')
 
     // Display size - 1 in order to always display the "Explore Safe Apps" card
     return resultApps.slice(0, size - 1)

--- a/src/components/Dashboard/SafeApps/Grid.tsx
+++ b/src/components/Dashboard/SafeApps/Grid.tsx
@@ -76,7 +76,7 @@ const useRankedApps = (allApps: SafeApp[], pinnedSafeApps: SafeApp[], size: numb
     // Get random apps that are not ranked and not featured
     const randomApps = sampleSize(nonRankedApps, size - 1 - topRankedSafeApps.length)
 
-    const resultApps = uniqBy(topRankedSafeApps.concat(pinnedSafeApps).concat(randomApps), 'id')
+    const resultApps = uniqBy(topRankedSafeApps.concat(pinnedSafeApps, randomApps), 'id')
 
     // Display size - 1 in order to always display the "Explore Safe Apps" card
     return resultApps.slice(0, size - 1)

--- a/src/components/Dashboard/SafeApps/Grid.tsx
+++ b/src/components/Dashboard/SafeApps/Grid.tsx
@@ -4,7 +4,7 @@ import { Button } from '@gnosis.pm/safe-react-components'
 import { generatePath, Link } from 'react-router-dom'
 import Skeleton from '@material-ui/lab/Skeleton/Skeleton'
 import { Grid } from '@material-ui/core'
-import { sampleSize } from 'lodash'
+import { sampleSize, uniq } from 'lodash'
 
 import { screenSm, screenMd } from 'src/theme/variables'
 import { useAppList } from 'src/routes/safe/components/Apps/hooks/appList/useAppList'
@@ -56,11 +56,10 @@ const StyledGrid = styled.div`
   }
 `
 
-const SafeAppsGrid = ({ size = 6 }: { size?: number }): ReactElement => {
-  const { allApps, pinnedSafeApps, togglePin, isLoading } = useAppList()
-
-  const displayedApps = useMemo(() => {
+const useRankedApps = (allApps: SafeApp[], pinnedSafeApps: SafeApp[], size: number): SafeApp[] => {
+  return useMemo(() => {
     if (!allApps.length) return []
+
     const trackData = getAppsUsageData()
     const rankedSafeAppIds = rankTrackedSafeApps(trackData)
     const featuredSafeAppIds = allApps.filter((app) => app.tags?.includes(FEATURED_APPS_TAG)).map((app) => app.id)
@@ -77,9 +76,16 @@ const SafeAppsGrid = ({ size = 6 }: { size?: number }): ReactElement => {
     // Get random apps that are not ranked and not featured
     const randomApps = sampleSize(nonRankedApps, size - 1 - topRankedSafeApps.length)
 
+    const resultApps = uniq(topRankedSafeApps.concat(pinnedSafeApps).concat(randomApps))
+
     // Display size - 1 in order to always display the "Explore Safe Apps" card
-    return topRankedSafeApps.concat(randomApps).slice(0, size - 1)
-  }, [allApps, size])
+    return resultApps.slice(0, size - 1)
+  }, [allApps, pinnedSafeApps, size])
+}
+
+const SafeAppsGrid = ({ size = 6 }: { size?: number }): ReactElement => {
+  const { allApps, pinnedSafeApps, isLoading, togglePin } = useAppList()
+  const displayedApps = useRankedApps(allApps, pinnedSafeApps, size)
 
   const path = generatePath(GENERIC_APPS_ROUTE)
 

--- a/src/routes/safe/components/Apps/hooks/appList/useRemoteSafeApps.ts
+++ b/src/routes/safe/components/Apps/hooks/appList/useRemoteSafeApps.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
+import { SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
 import { logError, Errors } from 'src/logic/exceptions/CodedException'
 import enqueueSnackbar from 'src/logic/notifications/store/actions/enqueueSnackbar'
 import { NOTIFICATIONS } from 'src/logic/notifications'
@@ -12,6 +13,17 @@ type ReturnType = {
   status: FETCH_STATUS
 }
 
+// Memoize the fetch request so that simulteneous calls
+// to this function return the same promise
+let fetchPromise: Promise<SafeAppData[]> | null = null
+const memoizedFetchSafeApps = (): Promise<SafeAppData[]> => {
+  if (!fetchPromise) {
+    fetchPromise = fetchSafeAppsList()
+  }
+  fetchPromise.finally(() => (fetchPromise = null))
+  return fetchPromise
+}
+
 const useRemoteSafeApps = (): ReturnType => {
   const [remoteSafeApps, setRemoteSafeApps] = useState<SafeApp[]>([])
   const [status, setStatus] = useState<FETCH_STATUS>(FETCH_STATUS.NOT_ASKED)
@@ -21,7 +33,7 @@ const useRemoteSafeApps = (): ReturnType => {
     const loadAppsList = async () => {
       setStatus(FETCH_STATUS.LOADING)
       try {
-        const result = await fetchSafeAppsList()
+        const result = await memoizedFetchSafeApps()
 
         if (result?.length) {
           setRemoteSafeApps(result.map((app) => ({ ...app, fetchStatus: FETCH_STATUS.SUCCESS, id: String(app.id) })))


### PR DESCRIPTION
As per @sche's feedback, pinned Safe Apps are now displayed in the Safe Apps widget with a priority over random apps.

Current logic:

1) Apps ranked by usage go first
2) Pinned Safe Apps go as a fallback
3) Fill up the remaining slots with random apps

Also fixed the issue that we were issuing two simultaneous requests to the remote Safe App list.