### PR TITLE
fix: add ignored errors to Sentry config

### DIFF
--- a/src/components/VirtualizedList/index.tsx
+++ b/src/components/VirtualizedList/index.tsx
@@ -4,12 +4,12 @@ import { Virtuoso } from 'react-virtuoso'
 // The ResizeObserver cannot deliver all observations in one animation frame.
 // The author of the `ResizeObserver` spec assures that it can be safely ignored:
 // https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded#comment86691361_49384120
+export const RESIZE_OBSERVER_ERRORS = [
+  'ResizeObserver loop completed with undelivered notifications.',
+  'ResizeObserver loop limit exceeded',
+]
 
 const ignoreResizeObserverErrors = (e: ErrorEvent) => {
-  const RESIZE_OBSERVER_ERRORS = [
-    'ResizeObserver loop completed with undelivered notifications.',
-    'ResizeObserver loop limit exceeded',
-  ]
   if (RESIZE_OBSERVER_ERRORS.includes(e.message)) {
     e.stopImmediatePropagation()
   }

--- a/src/components/VirtualizedList/index.tsx
+++ b/src/components/VirtualizedList/index.tsx
@@ -4,12 +4,12 @@ import { Virtuoso } from 'react-virtuoso'
 // The ResizeObserver cannot deliver all observations in one animation frame.
 // The author of the `ResizeObserver` spec assures that it can be safely ignored:
 // https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded#comment86691361_49384120
-export const RESIZE_OBSERVER_ERRORS = [
-  'ResizeObserver loop completed with undelivered notifications.',
-  'ResizeObserver loop limit exceeded',
-]
 
 const ignoreResizeObserverErrors = (e: ErrorEvent) => {
+  const RESIZE_OBSERVER_ERRORS = [
+    'ResizeObserver loop completed with undelivered notifications.',
+    'ResizeObserver loop limit exceeded',
+  ]
   if (RESIZE_OBSERVER_ERRORS.includes(e.message)) {
     e.stopImmediatePropagation()
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,6 @@ import { Integrations } from '@sentry/tracing'
 import Root from 'src/components/Root'
 import { SENTRY_DSN } from './utils/constants'
 import { disableMMAutoRefreshWarning } from './utils/mm_warnings'
-import { RESIZE_OBSERVER_ERRORS } from './components/VirtualizedList'
 
 disableMMAutoRefreshWarning()
 
@@ -24,7 +23,8 @@ Sentry.init({
     // Duplicate of Errors._800 emitted by promiEvent
     'Transaction was not mined within 50 blocks, please make sure your transaction was properly sent. Be aware that it might still be mined!',
     // Insignificant ResizeObserver errors
-    ...RESIZE_OBSERVER_ERRORS,
+    'ResizeObserver loop completed with undelivered notifications.',
+    'ResizeObserver loop limit exceeded',
   ],
 })
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { Integrations } from '@sentry/tracing'
 import Root from 'src/components/Root'
 import { SENTRY_DSN } from './utils/constants'
 import { disableMMAutoRefreshWarning } from './utils/mm_warnings'
+import { RESIZE_OBSERVER_ERRORS } from './components/VirtualizedList'
 
 disableMMAutoRefreshWarning()
 
@@ -15,8 +16,16 @@ Sentry.init({
   release: `safe-react@${process.env.REACT_APP_APP_VERSION}`,
   integrations: [new Integrations.BrowserTracing()],
   sampleRate: 0.1,
-  // ignore MetaMask errors we don't control
-  ignoreErrors: ['Internal JSON-RPC error', 'JsonRpcEngine', 'Non-Error promise rejection captured with keys: code'],
+  ignoreErrors: [
+    // MetaMask errors we don't control
+    'Internal JSON-RPC error',
+    'JsonRpcEngine',
+    'Non-Error promise rejection captured with keys: code',
+    // Duplicate of Errors._800 emitted by promiEvent
+    'Transaction was not mined within 50 blocks, please make sure your transaction was properly sent. Be aware that it might still be mined!',
+    // Insignificant ResizeObserver errors
+    ...RESIZE_OBSERVER_ERRORS,
+  ],
 })
 
 const root = document.getElementById('root')


### PR DESCRIPTION
## What it solves
Unnecessary errors in Sentry logs.

## How this PR fixes it
Three new errors have been added to the ignore list for Sentry:
- ResizeObserver loop completed with undelivered notifications.
- ResizeObserver loop limit exceeded
- Transaction was not mined within 50 blocks, please make sure your transaction was properly sent. Be aware that it might still be mined!

The first two are safe to ignore, [as clarified by the author of the `ResizeObserver`](https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded#comment86691361_49384120) (we do not show it in the console either). The latter we already have a `CodedException` for (`Errors._800`) but this is emitted from `Web3`.

## How to test it
1/2. Scroll excessibly up/down a large NFT list and observe no POST request to Sentry with either error message.
3. Create/execute a transaction that will revert. There should be no POST request to Sentry for that either (after 50 blocks).