### PR TITLE
fix: Transaction nav link to history instead of queue

### DIFF
--- a/src/components/AppLayout/Sidebar/useSidebarItems.tsx
+++ b/src/components/AppLayout/Sidebar/useSidebarItems.tsx
@@ -128,7 +128,7 @@ const useSidebarItems = (): ListItemType[] => {
       makeEntryItem({
         label: 'Transactions',
         iconType: 'transactionsInactive',
-        href: currentSafeRoutes.TRANSACTIONS_QUEUE,
+        href: currentSafeRoutes.TRANSACTIONS_HISTORY,
         subItems: transactionsSubItems,
       }),
       makeEntryItem({


### PR DESCRIPTION
## What it solves
Redirect the user to transaction history instead of transaction queue when clicking the transaction link in the sidebar navigation.
