### PR TITLE
feat: Add analytics for the Share App feature

### DIFF
--- a/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
+++ b/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
@@ -45,6 +45,7 @@ import Track from 'src/components/Track'
 import { didTxRevert } from 'src/logic/safe/store/actions/transactions/utils/transactionHelpers'
 import { useQuery } from 'src/logic/hooks/useQuery'
 import { ADDRESSED_ROUTE } from 'src/routes/routes'
+import { SAFE_APPS_EVENTS } from 'src/utils/events/safeApps'
 
 export const InlinePrefixedEthHashInfo = styled(PrefixedEthHashInfo)`
   display: inline-flex;
@@ -181,6 +182,8 @@ const pollSafeInfo = async (safeAddress: string): Promise<SafeInfo> => {
   })
 }
 
+const APP_URL_QUERY_PARAM = 'appUrl'
+
 function SafeCreationProcess(): ReactElement {
   const [safeCreationTxHash, setSafeCreationTxHash] = useState<string | undefined>()
   const [creationTxPromise, setCreationTxPromise] = useState<Promise<TransactionReceipt>>()
@@ -291,6 +294,10 @@ function SafeCreationProcess(): ReactElement {
         history.push({
           pathname: redirect,
         })
+      }
+
+      if (redirect.includes(APP_URL_QUERY_PARAM)) {
+        trackEvent({ ...SAFE_APPS_EVENTS.SHARED_APP_OPEN_AFTER_SAFE_CREATION })
       }
 
       return

--- a/src/routes/SafeAppLandingPage/SafeAppLandingPage.tsx
+++ b/src/routes/SafeAppLandingPage/SafeAppLandingPage.tsx
@@ -11,6 +11,8 @@ import { getAppInfoFromUrl } from 'src/routes/safe/components/Apps/utils'
 import { setChainId } from 'src/logic/config/utils'
 import { useQuery } from 'src/logic/hooks/useQuery'
 import useAsync from 'src/logic/hooks/useAsync'
+import { trackEvent } from 'src/utils/googleTagManager'
+import { SAFE_APPS_EVENTS } from 'src/utils/events/safeApps'
 import SafeAppDetails from 'src/routes/SafeAppLandingPage/components/SafeAppsDetails'
 import TryDemoSafe from 'src/routes/SafeAppLandingPage/components/TryDemoSafe'
 import UserSafe from './components/UserSafe'
@@ -55,6 +57,19 @@ const SafeAppLandingPage = (): ReactElement => {
   const availableChains = safeAppDetails?.chainIds || []
 
   const showLoader = isLoading || !safeAppDetails
+
+  useEffect(() => {
+    if (safeAppDetails) {
+      trackEvent({
+        ...SAFE_APPS_EVENTS.SHARED_APP_LANDING,
+        label: safeAppDetails?.name,
+      })
+      trackEvent({
+        ...SAFE_APPS_EVENTS.SHARED_APP_CHAIN_ID,
+        label: safeAppChainId,
+      })
+    }
+  }, [safeAppDetails, safeAppChainId])
 
   if (!safeAppUrl || !isValidChain || isSafeAppMissing) {
     return <Redirect to={WELCOME_ROUTE} />

--- a/src/routes/SafeAppLandingPage/SafeAppLandingPage.tsx
+++ b/src/routes/SafeAppLandingPage/SafeAppLandingPage.tsx
@@ -59,7 +59,7 @@ const SafeAppLandingPage = (): ReactElement => {
   const showLoader = isLoading || !safeAppDetails
 
   useEffect(() => {
-    if (safeAppDetails) {
+    if (!isLoading && safeAppDetails) {
       trackEvent({
         ...SAFE_APPS_EVENTS.SHARED_APP_LANDING,
         label: safeAppDetails?.name,
@@ -69,7 +69,7 @@ const SafeAppLandingPage = (): ReactElement => {
         label: safeAppChainId,
       })
     }
-  }, [safeAppDetails, safeAppChainId])
+  }, [isLoading, safeAppDetails, safeAppChainId])
 
   if (!safeAppUrl || !isValidChain || isSafeAppMissing) {
     return <Redirect to={WELCOME_ROUTE} />

--- a/src/routes/SafeAppLandingPage/components/TryDemoSafe.tsx
+++ b/src/routes/SafeAppLandingPage/components/TryDemoSafe.tsx
@@ -1,13 +1,25 @@
-import { ReactElement } from 'react'
-import { Link } from 'react-router-dom'
+import { MouseEvent, ReactElement } from 'react'
+import { Link, useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 import { Title, Button } from '@gnosis.pm/safe-react-components'
 
 import { demoSafeRoute } from 'src/routes/routes'
 import { secondary } from 'src/theme/variables'
 import DemoSvg from 'src/assets/icons/demo.svg'
+import { trackEvent } from 'src/utils/googleTagManager'
+import { SAFE_APPS_EVENTS } from 'src/utils/events/safeApps'
 
 const TryDemoSafe = ({ safeAppUrl }: { safeAppUrl: string | null }): ReactElement => {
+  const history = useHistory()
+  const demoSafeUrl = `${demoSafeRoute}?appUrl=${encodeURI(safeAppUrl || '')}`
+
+  const handleDemoSafeClick = (event: MouseEvent) => {
+    event.preventDefault()
+
+    trackEvent({ ...SAFE_APPS_EVENTS.SHARED_APP_OPEN_DEMO, label: safeAppUrl })
+    history.push(demoSafeUrl)
+  }
+
   return (
     <SafeDemoContainer>
       <Title size="xs">Want to try the app before using it?</Title>
@@ -16,9 +28,10 @@ const TryDemoSafe = ({ safeAppUrl }: { safeAppUrl: string | null }): ReactElemen
 
       {safeAppUrl && (
         <StyledDemoButton
+          onClick={handleDemoSafeClick}
+          to={demoSafeUrl}
           color="primary"
           component={Link}
-          to={`${demoSafeRoute}?appUrl=${encodeURI(safeAppUrl)}`}
           size="lg"
           variant="outlined"
         >

--- a/src/utils/events/safeApps.ts
+++ b/src/utils/events/safeApps.ts
@@ -34,6 +34,22 @@ const SAFE_APPS = {
     event: GTM_EVENT.META,
     action: 'Legacy API call',
   },
+  SHARED_APP_LANDING: {
+    event: GTM_EVENT.META,
+    action: 'Shared App landing page visited',
+  },
+  SHARED_APP_CHAIN_ID: {
+    event: GTM_EVENT.META,
+    action: 'Shared App chainId',
+  },
+  SHARED_APP_OPEN_DEMO: {
+    event: GTM_EVENT.META,
+    action: 'Open demo safe from shared app',
+  },
+  SHARED_APP_OPEN_AFTER_SAFE_CREATION: {
+    event: GTM_EVENT.META,
+    action: 'Open shared app after Safe creation',
+  },
 }
 
 const SAFE_APPS_CATEGORY = 'safe-apps'


### PR DESCRIPTION
## What it solves
resolves gnosis/safe-react-apps#426

## How this PR fixes it
Adding new 4 track events:

1) When opening the Share App landing page we send 2 events, the concrete app and the chain where the app was shared
2) When opening the demo safe we send another event
3) After starting the safe creation from the landing page, if the user completes it and access the safe app we send another event
