### PR TITLE
style: Adjust gap between pendings txs on dashboard widget

### DIFF
--- a/src/components/Dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/Dashboard/PendingTxs/PendingTxsList.tsx
@@ -27,10 +27,8 @@ const SkeletonWrapper = styled.div`
 const StyledList = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 12px;
+  gap: 15px;
   width: 100%;
-  height: 100%;
 `
 
 const StyledWidgetTitle = styled.div`


### PR DESCRIPTION
## What it solves
Part of #3693

The space between pending transactions in the dashboard widget was stretched if there were less than 4 transactions.

## How this PR fixes it

Instead of stretching the space, there is a fixed gap between each transaction. The gap is also slightly increased so that the space is filled when there are 4 transactions displayed.

## How to test it

1. Open the safe app
2. Navigate to the dashboard
3. With less than 4 transactions, observe whitespace at the bottom of the widget
4. With 4 transactions, observe the pending tx widget has the same height as the featured apps widget

## Screenshots

![Screenshot 2022-04-28 at 15 58 05](https://user-images.githubusercontent.com/5880855/165769342-adde18b2-d3fc-435b-90f7-fe273dd01fd5.png)
![Screenshot 2022-04-28 at 15 58 18](https://user-images.githubusercontent.com/5880855/165769349-0b302c76-561e-4657-9669-25b61b809aa5.png)

