### PR TITLE
Fix: do not increase Dashboard token count when Ether balance is 0

### DIFF
--- a/src/components/Dashboard/Overview/Overview.tsx
+++ b/src/components/Dashboard/Overview/Overview.tsx
@@ -106,8 +106,8 @@ const Overview = (): ReactElement => {
     history.push(generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, { safeAddress: address, shortName }))
   }
 
-  // Ether is always returned even when its balance is 0
-  const tokenCount = useMemo(() => balances.filter((token) => token.tokenBalance === '0').length, [balances])
+  // Native token is always returned even when its balance is 0
+  const tokenCount = useMemo(() => balances.filter((token) => token.tokenBalance !== '0').length, [balances])
 
   return (
     <WidgetContainer>

--- a/src/components/Dashboard/Overview/Overview.tsx
+++ b/src/components/Dashboard/Overview/Overview.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { ReactElement, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 import { Text, Identicon } from '@gnosis.pm/safe-react-components'
@@ -106,6 +106,9 @@ const Overview = (): ReactElement => {
     history.push(generateSafeRoute(SAFE_ROUTES.ASSETS_BALANCES, { safeAddress: address, shortName }))
   }
 
+  // Ether is always returned even when its balance is 0
+  const tokenCount = useMemo(() => balances.filter((token) => token.tokenBalance === '0').length, [balances])
+
   return (
     <WidgetContainer>
       <DashboardTitle>Dashboard</DashboardTitle>
@@ -138,7 +141,7 @@ const Overview = (): ReactElement => {
                 <Text color="inputDefault" size="lg">
                   Tokens
                 </Text>
-                <StyledText size="xl">{balances.length}</StyledText>
+                <StyledText size="xl">{tokenCount}</StyledText>
               </Grid>
               <Grid item xs={3}>
                 <Text color="inputDefault" size="lg">


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-react/issues/3840

## How this PR fixes it
Do not include in Safe token count tokens with 0 balance

## How to test it
1. Open the Dashboard for a Safe containing some Ether and other tokens and observe that Ether counts as a token in Dashboard Overview widget
2. Open the Dashboard for a Safe containing 0 Ether but other tokens and observe that the Dashboard Overview widget does not count Ether

## Screenshots
_Balances_
<img width="516" alt="Screenshot 2022-05-02 at 13 42 17" src="https://user-images.githubusercontent.com/32431609/166228479-21409b2b-ca00-4d20-97d9-3539d066d35c.png">

_Dashboard_
<img width="410" alt="Screenshot 2022-05-02 at 13 43 48" src="https://user-images.githubusercontent.com/32431609/166228434-3771288e-e9b5-4428-bb57-76087c4f8049.png">


