### PR TITLE
style: Adjust sidebar threshold bubble position

### DIFF
--- a/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
+++ b/src/components/SafeListSidebar/SafeList/SafeListItem.tsx
@@ -1,9 +1,10 @@
-import { Text, Icon, Button } from '@gnosis.pm/safe-react-components'
+import { Text, Icon, Button, Identicon } from '@gnosis.pm/safe-react-components'
 import { useEffect, useRef, ReactElement } from 'react'
 import { useHistory } from 'react-router'
 import ListItem from '@material-ui/core/ListItem/ListItem'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction/ListItemSecondaryAction'
 import styled from 'styled-components'
+import { Box } from '@material-ui/core'
 
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
@@ -57,7 +58,13 @@ const StyledPrefixedEthHashInfo = styled(PrefixedEthHashInfo)`
 `
 
 const AddressContainer = styled.div`
-  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  & img {
+    display: block;
+  }
 `
 
 type Props = {
@@ -123,8 +130,11 @@ const SafeListItem = ({
     <ListItem button onClick={handleOpenSafe} ref={safeRef}>
       <StyledIcon type="check" size="md" color="primary" checked={isCurrentSafe} />
       <AddressContainer>
-        {threshold && owners && <Threshold threshold={threshold} owners={owners.length} size={11} />}
-        <StyledPrefixedEthHashInfo hash={address} name={safeName} shortName={shortName} showAvatar shortenHash={4} />
+        <Box position="relative">
+          {threshold && owners && <Threshold threshold={threshold} owners={owners.length} size={11} />}
+          <Identicon address={address} size="md" />
+        </Box>
+        <StyledPrefixedEthHashInfo hash={address} name={safeName} shortName={shortName} shortenHash={4} />
       </AddressContainer>
       <ListItemSecondaryAction>
         {ethBalance ? (


### PR DESCRIPTION
## What it solves
Fix for #3891

## How this PR fixes it
The Threshold bubble is positioned relative to the Identicon size instead of the row

## How to test it
1. Open the Safe app
2. Add a safe with a safe name
3. Add a safe without a safe name
4. Open the sidebar
5. Observe the threshold bubble position is the same for both list items

## Screenshots
![Screenshot 2022-05-03 at 10 47 46](https://user-images.githubusercontent.com/5880855/166426583-0975c7dc-77e1-4a6e-bee3-ffc6656662f3.png)

