### PR TITLE
style: move share tx button to top

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -27,6 +27,9 @@ import useTxStatus from 'src/logic/hooks/useTxStatus'
 import { useSelector } from 'react-redux'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 import TxModuleInfo from './TxModuleInfo'
+import Track from 'src/components/Track'
+import { TX_LIST_EVENTS } from 'src/utils/events/txList'
+import TxShareButton from './TxShareButton'
 
 const NormalBreakingText = styled(Text)`
   line-break: normal;
@@ -135,6 +138,11 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
     isMultiSend ? (
       <>
         <div className={cn('tx-summary', { 'will-be-replaced': willBeReplaced })}>
+          <div className="tx-share">
+            <Track {...TX_LIST_EVENTS.COPY_DEEPLINK}>
+              <TxShareButton txId={data.txId} />
+            </Track>
+          </div>
           <TxSummary txDetails={data} />
         </div>
         {getModuleDetails()}
@@ -157,6 +165,11 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
             'will-be-replaced': willBeReplaced,
           })}
         >
+          <div className="tx-share">
+            <Track {...TX_LIST_EVENTS.COPY_DEEPLINK}>
+              <TxShareButton txId={data.txId} />
+            </Track>
+          </div>
           <TxDataGroup txDetails={data} />
         </div>
         {getModuleDetails()}

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -131,6 +131,16 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
     )
   }
 
+  const TrackedShareButton = () => {
+    return (
+      <div className="tx-share">
+        <Track {...TX_LIST_EVENTS.COPY_DEEPLINK}>
+          <TxShareButton txId={data.txId} />
+        </Track>
+      </div>
+    )
+  }
+
   const customTxNoData = isCustomTxInfo(data.txInfo) && !data.txInfo.methodName && !parseInt(data.txInfo.dataSize, 10)
   const onChainRejection = isCancelTxDetails(data.txInfo) && isMultiSigExecutionDetails(data.detailedExecutionInfo)
   const noTxDataBlock = customTxNoData && !onChainRejection
@@ -138,11 +148,7 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
     isMultiSend ? (
       <>
         <div className={cn('tx-summary', { 'will-be-replaced': willBeReplaced })}>
-          <div className="tx-share">
-            <Track {...TX_LIST_EVENTS.COPY_DEEPLINK}>
-              <TxShareButton txId={data.txId} />
-            </Track>
-          </div>
+          <TrackedShareButton />
           <TxSummary txDetails={data} />
         </div>
         {getModuleDetails()}
@@ -165,11 +171,7 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
             'will-be-replaced': willBeReplaced,
           })}
         >
-          <div className="tx-share">
-            <Track {...TX_LIST_EVENTS.COPY_DEEPLINK}>
-              <TxShareButton txId={data.txId} />
-            </Track>
-          </div>
+          <TrackedShareButton />
           <TxDataGroup txDetails={data} />
         </div>
         {getModuleDetails()}

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -34,6 +34,7 @@ import TxShareButton from './TxShareButton'
 const NormalBreakingText = styled(Text)`
   line-break: normal;
   word-break: normal;
+  padding-right: 32px;
 `
 
 const TxDataGroup = ({ txDetails }: { txDetails: ExpandedTxDetails }): ReactElement | null => {

--- a/src/routes/safe/components/Transactions/TxList/TxShareButton.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxShareButton.tsx
@@ -5,10 +5,18 @@ import useSafeAddress from 'src/logic/currentSession/hooks/useSafeAddress'
 
 import { getPrefixedSafeAddressSlug, SAFE_ADDRESS_SLUG, SAFE_ROUTES, TRANSACTION_ID_SLUG } from 'src/routes/routes'
 import { PUBLIC_URL } from 'src/utils/constants'
+import styled from 'styled-components'
 
 type Props = {
   txId: string
 }
+
+const StyledCopyToClipboardBtn = styled(CopyToClipboardBtn)`
+  background: #f6f7f8;
+  border-radius: 4px;
+  height: 32px;
+  width: 32px;
+`
 
 const TxShareButton = ({ txId }: Props): ReactElement => {
   const { shortName, safeAddress } = useSafeAddress()
@@ -19,7 +27,7 @@ const TxShareButton = ({ txId }: Props): ReactElement => {
   })
   const txDetailsLink = `${window.location.origin}${PUBLIC_URL}${txDetailsPathname}`
 
-  return <CopyToClipboardBtn textToCopy={txDetailsLink} iconType="share" />
+  return <StyledCopyToClipboardBtn textToCopy={txDetailsLink} iconType="share" />
 }
 
 export default TxShareButton

--- a/src/routes/safe/components/Transactions/TxList/TxShareButton.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxShareButton.tsx
@@ -16,6 +16,17 @@ const StyledCopyToClipboardBtn = styled(CopyToClipboardBtn)`
   border-radius: 4px;
   height: 32px;
   width: 32px;
+
+  & span {
+    width: 32px;
+    height: 32px;
+    justify-content: center;
+    align-items: center;
+  }
+
+  & svg {
+    padding-right: 2px;
+  }
 `
 
 const TxShareButton = ({ txId }: Props): ReactElement => {

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -10,13 +10,10 @@ import {
   isMultiSigExecutionDetails,
 } from 'src/logic/safe/store/models/types/gateway.d'
 import { NOT_AVAILABLE } from './utils'
-import TxShareButton from './TxShareButton'
 import TxInfoMultiSend from './TxInfoMultiSend'
 import DelegateCallWarning from './DelegateCallWarning'
 import { TxDataRow } from 'src/routes/safe/components/Transactions/TxList/TxDataRow'
 import { sm } from 'src/theme/variables'
-import Track from 'src/components/Track'
-import { TX_LIST_EVENTS } from 'src/utils/events/txList'
 
 const StyledButtonLink = styled(ButtonLink)`
   margin-top: ${sm};
@@ -60,12 +57,6 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
 
   return (
     <>
-      <div className="tx-share">
-        <Track {...TX_LIST_EVENTS.COPY_DEEPLINK}>
-          <TxShareButton txId={txDetails.txId} />
-        </Track>
-      </div>
-
       {txData?.operation === Operation.DELEGATE && (
         <div className="tx-operation">
           <DelegateCallWarning showWarning={!txData.trustedDelegateCallTarget} />

--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -395,6 +395,8 @@ export const TxDetailsContainer = styled.div`
   }
 
   .tx-details {
+    position: relative;
+
     &.not-executed {
       grid-row-end: span 2;
     }


### PR DESCRIPTION
## What it solves
Resolves #3508 

## How this PR fixes it
Moves the share button to top.

## How to test it
Expand the accordion of any tx in the queue or history.
The share button should always be in the top right of the left section (see screenshot)

## Analytics changes
none, the share button should still be tracked.

## Screenshots
![localhost_3000_app_rin_0x7d9A7D9C72e2905b8F6cC866f33c594895df6c6C_transactions_history (1)](https://user-images.githubusercontent.com/2670790/166987219-407972ff-cd3a-4a58-aa45-34ad13380ae5.png)

