### PR TITLE
fix: @truffle/hdwallet-provider cannot be a dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
     "web3": "1.7.0",
     "web3-core": "^1.7.0",
     "web3-eth-contract": "^1.7.0",
-    "web3-utils": "^1.7.0"
+    "web3-utils": "^1.7.0",
+    "@truffle/hdwallet-provider": "^2.0.8"
   },
   "devDependencies": {
     "@gnosis.pm/safe-core-sdk-types": "1.0.0",
@@ -170,7 +171,6 @@
     "cypress-file-upload": "^5.0.8",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "@truffle/hdwallet-provider": "^2.0.8",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.24.2",


### PR DESCRIPTION
## What it solves
@truffle/hdwallet-provider cannot be a dev dep
