### PR TITLE
fix: enables intercom

### DIFF
--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -203,7 +203,7 @@ const CookiesBanner = isDesktop
       const [localAnalytics, setLocalAnalytics] = useState(false)
 
       const { cookieBannerOpen } = useSelector(cookieBannerState)
-      const isSafeAppView = useSafeAppUrl().getAppUrl() !== ''
+      const isSafeAppView = !!useSafeAppUrl().getAppUrl()
 
       const openBanner = useCallback(
         (key?: COOKIE_IDS): void => {

--- a/src/components/CookiesBanner/index.tsx
+++ b/src/components/CookiesBanner/index.tsx
@@ -203,7 +203,7 @@ const CookiesBanner = isDesktop
       const [localAnalytics, setLocalAnalytics] = useState(false)
 
       const { cookieBannerOpen } = useSelector(cookieBannerState)
-      const isSafeAppView = useSafeAppUrl().getAppUrl() !== null
+      const isSafeAppView = useSafeAppUrl().getAppUrl() !== ''
 
       const openBanner = useCallback(
         (key?: COOKIE_IDS): void => {

--- a/src/logic/hooks/useSafeAppUrl.tsx
+++ b/src/logic/hooks/useSafeAppUrl.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import { sanitizeUrl } from 'src/utils/sanitizeUrl'
 
 type AppUrlReturnType = {
-  getAppUrl: () => string | null
+  getAppUrl: () => string
 }
 
 export const useSafeAppUrl = (): AppUrlReturnType => {


### PR DESCRIPTION
## What it solves
Resolves #3876 

## How this PR fixes it
Fixes a wrong comparison which caused the intercom to never load.

## How to test it
Open the safe web interface and accept the cookies.

## Analytics changes
None

## Screenshots
No real changes. The intercom still looks the same.