### PR TITLE
Chore: add e2e tests for Intercom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tsconfig.tsbuildinfo
 public/**/*.js
 jest.results.json
 *.#*
+cypress/videos
+cypress/screenshots

--- a/cypress/integration/intercom.spec.js
+++ b/cypress/integration/intercom.spec.js
@@ -1,5 +1,5 @@
 const RINKEBY_TEST_SAFE = 'rin:0xFfDC1BcdeC18b1196e7FA04246295DE3A17972Ac'
-const intercomIfame = 'iframe[id="intercom-frame"]'
+const intercomIframe = 'iframe[id="intercom-frame"]'
 const intercomButton = '[aria-label="Open Intercom Messenger"]'
 const fakeIntercomButton = 'img[alt="Open Intercom"]'
 
@@ -19,7 +19,7 @@ describe('Intercom and cookie prefs', () => {
     cy.contains('a', 'Accept all').click()
 
     // Intercom is now active
-    cy.get(intercomIfame).should('exist')
+    cy.get(intercomIframe).should('exist')
     cy.get(fakeIntercomButton).should('not.exist')
     cy.get(intercomButton).click()
     cy.get('#intercom-container').should('exist')
@@ -33,7 +33,7 @@ describe('Intercom and cookie prefs', () => {
 
     // Go to Settings and change the cookie settings
     cy.visit(`/${RINKEBY_TEST_SAFE}/settings`)
-    cy.get(intercomIfame).should('exist')
+    cy.get(intercomIframe).should('exist')
     cy.contains('button', 'Preferences').click()
     cy.contains('Community support & updates').click()
     cy.contains('a', 'Accept selection').click()

--- a/cypress/integration/intercom.spec.js
+++ b/cypress/integration/intercom.spec.js
@@ -1,0 +1,45 @@
+const RINKEBY_TEST_SAFE = 'rin:0xFfDC1BcdeC18b1196e7FA04246295DE3A17972Ac'
+const intercomIfame = 'iframe[id="intercom-frame"]'
+const intercomButton = '[aria-label="Open Intercom Messenger"]'
+const fakeIntercomButton = 'img[alt="Open Intercom"]'
+
+describe('Intercom and cookie prefs', () => {
+  it('should show the Intercom chat if cookies are enabled', () => {
+    cy.visit('/')
+
+    // Don't accept Intercom cookies
+    cy.contains('a', 'Accept selection').click()
+
+    // Click on the Intercom button
+    cy.get(fakeIntercomButton).click()
+
+    // Cookie preferences appear
+    cy.contains('You attempted to open the customer support chat. Please accept the community support & updates cookies')
+
+    cy.contains('a', 'Accept all').click()
+
+    // Intercom is now active
+    cy.get(intercomIfame).should('exist')
+    cy.get(fakeIntercomButton).should('not.exist')
+    cy.get(intercomButton).click()
+    cy.get('#intercom-container').should('exist')
+
+    // Intercom should be disabled on a Safe App page
+    cy.visit(`/${RINKEBY_TEST_SAFE}/apps`)
+
+    // Click on first app link
+    cy.get('[data-testid="safe_apps__all-apps-container"] a').first().click()
+    cy.get(intercomButton).should('not.exist')
+
+    // Go to Settings and change the cookie settings
+    cy.visit(`/${RINKEBY_TEST_SAFE}/settings`)
+    cy.get(intercomIfame).should('exist')
+    cy.contains('button', 'Preferences').click()
+    cy.contains('Community support & updates').click()
+    cy.contains('a', 'Accept selection').click()
+
+    // Intercom should be now disabled
+    cy.get(intercomButton).should('not.exist')
+    cy.get(fakeIntercomButton).should('be.visible')
+  })
+})


### PR DESCRIPTION
Intercom was broken for 2 weeks (see #3876), so I added a test for it.

* Enables the Intercom cookies
* Opens Intercom
* Goes to a Safe App to check that Intercom is disabled
* Goes to settings and disables Intercom cookies