### PR TITLE
Refactor: useAsync signature

### DIFF
--- a/src/logic/hooks/__tests__/useAsync.test.ts
+++ b/src/logic/hooks/__tests__/useAsync.test.ts
@@ -1,65 +1,31 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { act, renderHook } from '@testing-library/react-hooks'
 import useAsync from '../useAsync'
 
-describe('useAsync tests', () => {
-  it('returns a successful result', async () => {
-    const fakeCallback = jest.fn(() => Promise.resolve('success'))
+// Jest tests for the useAsync hook
+describe('useAsync hook', () => {
+  it('should return the correct state when the promise resolves', async () => {
+    const { result } = renderHook(() => useAsync(() => Promise.resolve('test'), []))
 
-    const { result, waitForNextUpdate } = renderHook(() => useAsync(fakeCallback))
+    expect(result.current).toEqual([undefined, undefined, true])
 
-    await waitForNextUpdate()
-
-    expect(result.current).toEqual({ result: 'success', error: undefined, isLoading: false })
-
-    expect(fakeCallback).toHaveBeenCalledTimes(1)
-  })
-
-  it('returns an error', async () => {
-    const fakeCallback = jest.fn(() => Promise.reject(new Error('failure')))
-
-    const { result, waitForNextUpdate } = renderHook(() => useAsync(fakeCallback))
-
-    await waitForNextUpdate()
-
-    expect(result.current.result).toBe(undefined)
-    expect(result.current.error).toBeDefined()
-    expect(result.current.error!.message).toBe('failure')
-
-    expect(fakeCallback).toHaveBeenCalledTimes(1)
-  })
-
-  it('ignores a stale result if a new request has been launched already', async () => {
-    // This will resolve AFTER the second callback but the result should be ignored
-    const fakeCallback1 = jest.fn(() => {
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve('success 1')
-        }, 10)
-      })
+    // Wait for the promise to resolve
+    await act(async () => {
+      await Promise.resolve()
     })
 
-    const fakeCallback2 = jest.fn(() => Promise.resolve('success 2'))
+    expect(result.current).toEqual(['test', undefined, false])
+  })
 
-    let counter = 0
-    const { result, waitForNextUpdate, rerender } = renderHook(() => {
-      const callback = counter > 0 ? fakeCallback2 : fakeCallback1
-      counter += 1
-      return useAsync(callback)
+  it('should return the correct state when the promise rejects', async () => {
+    const { result } = renderHook(() => useAsync(() => Promise.reject('test'), []))
+
+    expect(result.current).toEqual([undefined, undefined, true])
+
+    // Wait for the promise to resolve
+    await act(async () => {
+      await Promise.resolve()
     })
 
-    expect(result.current.result).toBe(undefined)
-    expect(result.current.error).toBe(undefined)
-    expect(result.current.isLoading).toBe(true)
-
-    rerender() // re-render immediately
-
-    await waitForNextUpdate()
-
-    expect(result.current.result).toBe('success 2')
-    expect(result.current.error).toBe(undefined)
-    expect(result.current.isLoading).toBe(false)
-
-    expect(fakeCallback1).toHaveBeenCalledTimes(1)
-    expect(fakeCallback2).toHaveBeenCalledTimes(1)
+    expect(result.current).toEqual([undefined, 'test', false])
   })
 })

--- a/src/logic/hooks/useEstimateSafeTxGas.tsx
+++ b/src/logic/hooks/useEstimateSafeTxGas.tsx
@@ -1,5 +1,4 @@
 import { Operation } from '@gnosis.pm/safe-react-gateway-sdk'
-import { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 
 import { estimateSafeTxGas } from 'src/logic/safe/transactions/gas'
@@ -24,7 +23,7 @@ export const useEstimateSafeTxGas = ({
   const defaultEstimation = '0'
   const { address: safeAddress, currentVersion: safeVersion } = useSelector(currentSafe)
 
-  const requestSafeTxGas = useCallback((): Promise<string> => {
+  const [result, error] = useAsync<string>(() => {
     if (isRejectTx || !txData) return Promise.resolve(defaultEstimation)
 
     return estimateSafeTxGas(
@@ -38,8 +37,6 @@ export const useEstimateSafeTxGas = ({
       safeVersion,
     )
   }, [isRejectTx, operation, safeAddress, safeVersion, txAmount, txData, txRecipient])
-
-  const { result, error } = useAsync<string>(requestSafeTxGas)
 
   return { result: result || defaultEstimation, error }
 }

--- a/src/logic/hooks/useRecommendedNonce.tsx
+++ b/src/logic/hooks/useRecommendedNonce.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { getRecommendedNonce } from 'src/logic/safe/api/fetchSafeTxGasEstimation'
 import { getLastTxNonce } from 'src/logic/safe/store/selectors/gatewayTransactions'
@@ -7,11 +6,9 @@ import useAsync from 'src/logic/hooks/useAsync'
 const useRecommendedNonce = (safeAddress: string): number => {
   const lastTxNonce = useSelector(getLastTxNonce) || -1
 
-  const getNonce = useCallback(() => {
+  const [result] = useAsync<number>(() => {
     return getRecommendedNonce(safeAddress)
   }, [safeAddress])
-
-  const { result } = useAsync<number>(getNonce)
 
   return result == null ? lastTxNonce + 1 : result
 }

--- a/src/routes/SafeAppLandingPage/SafeAppLandingPage.tsx
+++ b/src/routes/SafeAppLandingPage/SafeAppLandingPage.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useCallback, useEffect, useMemo } from 'react'
+import { ReactElement, useEffect, useMemo } from 'react'
 import { Redirect } from 'react-router-dom'
 import styled from 'styled-components'
 import { Card, Loader } from '@gnosis.pm/safe-react-components'
@@ -36,23 +36,16 @@ const SafeAppLandingPage = (): ReactElement => {
   const safeAppDetailsFromConfigService = appList.find(({ url }) => safeAppUrl === url)
 
   // fetch Safe App details from Manifest.json
-  const fetchManifest = useCallback(async () => {
+  const [safeAppDetailsFromManifest, manifestError, isManifestLoading] = useAsync<SafeApp>(async () => {
     if (safeAppUrl) {
       return getAppInfoFromUrl(safeAppUrl)
     }
-
     throw new Error('No Safe App URL provided.')
   }, [safeAppUrl])
 
-  const {
-    result: safeAppDetailsFromManifest,
-    error: isManifestError,
-    isLoading: isManifestLoading,
-  } = useAsync<SafeApp>(fetchManifest)
-
   const safeAppDetails = safeAppDetailsFromConfigService || safeAppDetailsFromManifest
   const isLoading = isConfigServiceLoading || isManifestLoading
-  const isSafeAppMissing = !isLoading && !safeAppDetails && isManifestError
+  const isSafeAppMissing = !isLoading && !safeAppDetails && manifestError
 
   const availableChains = safeAppDetails?.chainIds || []
 

--- a/src/routes/safe/components/Transactions/TxList/TxSingularDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSingularDetails.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useCallback } from 'react'
+import { ReactElement } from 'react'
 import { useParams } from 'react-router-dom'
 import { Loader } from '@gnosis.pm/safe-react-components'
 import { shallowEqual, useSelector } from 'react-redux'
@@ -38,11 +38,8 @@ const TxSingularDetails = (): ReactElement => {
   const { [TRANSACTION_ID_SLUG]: txId = '' } = useParams<SafeRouteSlugs>()
   const { transaction, txLocation } = useStoredTx(txId)
 
-  // When this callback changes, we refetch the tx details
-  const fetchTxDetails = useCallback(() => fetchSafeTransaction(txId), [txId])
-
   // Fetch tx details
-  const { result: fetchedTx, error } = useAsync<TransactionDetails>(fetchTxDetails)
+  const [fetchedTx, error] = useAsync<TransactionDetails>(() => fetchSafeTransaction(txId), [txId])
 
   if (error) {
     const safeParams = extractPrefixedSafeAddress()


### PR DESCRIPTION
* Use an array signature for easier naming of returned variables
* Pass a callback and the list of dependencies instead of useCallback