### PR TITLE
Refactor: execute tx and parse errors in separate places

### DIFF
--- a/src/logic/contracts/__tests__/safeContractErrors.test.ts
+++ b/src/logic/contracts/__tests__/safeContractErrors.test.ts
@@ -1,19 +1,19 @@
-import { decodeMessage } from '../safeContractErrors'
+import { _decodeErrorMessage } from '../safeContractErrors'
 
-describe('decodeMessage', () => {
+describe('_decodeErrorMessage', () => {
   it('returns safe errors', () => {
-    expect(decodeMessage('GS000: Could not finish initialization')).toBe('GS000: Could not finish initialization')
+    expect(_decodeErrorMessage('GS000: Could not finish initialization')).toBe('GS000: Could not finish initialization')
   })
 
   it('returns safe errors irregardless of place in error', () => {
-    expect(decodeMessage('testGS000test')).toBe('GS000: Could not finish initialization')
-    expect(decodeMessage('test GS000 test')).toBe('GS000: Could not finish initialization')
+    expect(_decodeErrorMessage('testGS000test')).toBe('GS000: Could not finish initialization')
+    expect(_decodeErrorMessage('test GS000 test')).toBe('GS000: Could not finish initialization')
   })
   it('returns safe errors irregardless of case', () => {
-    expect(decodeMessage('gs000: testing')).toBe('GS000: Could not finish initialization')
+    expect(_decodeErrorMessage('gs000: testing')).toBe('GS000: Could not finish initialization')
   })
 
   it('returns provided errors if not safe errors', () => {
-    expect(decodeMessage('Not a Safe error')).toBe('Not a Safe error')
+    expect(_decodeErrorMessage('Not a Safe error')).toBe('Not a Safe error')
   })
 })

--- a/src/logic/contracts/safeContractErrors.ts
+++ b/src/logic/contracts/safeContractErrors.ts
@@ -1,42 +1,19 @@
 import abi from 'ethereumjs-abi'
-
 import { CONTRACT_ERRORS, CONTRACT_ERROR_CODES } from 'src/logic/contracts/contracts.d'
-import { getWeb3 } from 'src/logic/wallets/getWeb3'
-import { GnosisSafe } from 'src/types/contracts/gnosis_safe.d'
-import { logError, Errors } from '../exceptions/CodedException'
 
-export const decodeMessage = (message: string): string => {
+export const _decodeErrorMessage = (message: string): string => {
   const code = CONTRACT_ERROR_CODES.find((code) => {
     return message.toUpperCase().includes(code.toUpperCase())
   })
-
   return code ? `${code}: ${CONTRACT_ERRORS[code]}` : message
 }
 
-export const getContractErrorMessage = async ({
-  safeInstance,
-  from,
-  data,
-}: {
-  safeInstance: GnosisSafe
-  from: string
-  data: string
-}): Promise<string | undefined> => {
-  const web3 = getWeb3()
-
-  try {
-    const returnData = await web3.eth.call({
-      to: safeInstance.options.address,
-      from,
-      value: 0,
-      data,
-    })
-
-    const returnBuffer = Buffer.from(returnData.slice(2), 'hex')
-
-    const contractOutput = abi.rawDecode(['string'], returnBuffer.slice(4))[0]
-    return decodeMessage(contractOutput)
-  } catch (err) {
-    logError(Errors._817, err.message)
+export const parseContractError = (contractResponse: string | Error): string => {
+  if (contractResponse instanceof Error) {
+    return _decodeErrorMessage(contractResponse.message)
   }
+
+  const returnBuffer = Buffer.from(contractResponse.slice(2), 'hex')
+  const contractOutput = abi.rawDecode(['string'], returnBuffer.slice(4))[0]
+  return _decodeErrorMessage(contractOutput)
 }


### PR DESCRIPTION
`getContractErrorMessage` was a misleading name. It was not getting anything, it was actually doing a tx execution, catching and parsing possible errors.

I've moved the eth call into the tx sender, renamed and refactored the error parsing function.