### PR TITLE
fix: remove `+L2` suffix from `currentVersion`

### DIFF
--- a/src/logic/safe/store/reducer/safe.ts
+++ b/src/logic/safe/store/reducer/safe.ts
@@ -55,7 +55,6 @@ const updateSafeProps = (prevSafe, safe) => {
       } else {
         // Temp fix
         if (key === 'currentVersion' && safe[key].endsWith('+L2')) {
-          console.log(key, safe[key])
           record.set(key, safe[key].replace('+L2', ''))
         } else {
           // By default we overwrite the value. This is for strings, numbers and unset values

--- a/src/logic/safe/store/reducer/safe.ts
+++ b/src/logic/safe/store/reducer/safe.ts
@@ -53,8 +53,14 @@ const updateSafeProps = (prevSafe, safe) => {
             : record.update(key, (current) => current.merge(safe[key]))
         }
       } else {
-        // By default we overwrite the value. This is for strings, numbers and unset values
-        record.set(key, safe[key])
+        // Temp fix
+        if (key === 'currentVersion' && safe[key].endsWith('+L2')) {
+          console.log(key, safe[key])
+          record.set(key, safe[key].replace('+L2', ''))
+        } else {
+          // By default we overwrite the value. This is for strings, numbers and unset values
+          record.set(key, safe[key])
+        }
       }
     })
   })


### PR DESCRIPTION
## What it solves
Resolves retrieval of contract ABIs

## How this PR fixes it
The `currentVersion` -`+L2` suffix is removed before saving to the store.

## How to test it
Open a Safe on an L2 network and create/execute a transaction. There should be no `Code 815: Error preparing transaction sender` warning in the console preventing you from executing the transaction.

## Note
This needs to be revisited with a cleaner fix.