### PR TITLE
fix: clean meta when retrieving contract

### DIFF
--- a/src/logic/contracts/safeContracts.ts
+++ b/src/logic/contracts/safeContracts.ts
@@ -1,4 +1,5 @@
 import semverSatisfies from 'semver/functions/satisfies'
+import semverClean from 'semver/functions/clean'
 import {
   getSafeSingletonDeployment,
   getSafeL2SingletonDeployment,
@@ -268,7 +269,7 @@ export const estimateGasForDeployingSafe = async (
 }
 
 export const getGnosisSafeInstanceAt = (safeAddress: string, safeVersion: string): GnosisSafe => {
-  const safeSingletonDeployment = getSafeContractDeployment({ safeVersion })
+  const safeSingletonDeployment = getSafeContractDeployment({ safeVersion: semverClean(safeVersion) })
 
   const web3 = getWeb3()
   return new web3.eth.Contract(safeSingletonDeployment?.abi as AbiItem[], safeAddress) as unknown as GnosisSafe

--- a/src/logic/safe/store/reducer/safe.ts
+++ b/src/logic/safe/store/reducer/safe.ts
@@ -53,13 +53,8 @@ const updateSafeProps = (prevSafe, safe) => {
             : record.update(key, (current) => current.merge(safe[key]))
         }
       } else {
-        // Temp fix
-        if (key === 'currentVersion' && safe[key].endsWith('+L2')) {
-          record.set(key, safe[key].replace('+L2', ''))
-        } else {
-          // By default we overwrite the value. This is for strings, numbers and unset values
-          record.set(key, safe[key])
-        }
+        // By default we overwrite the value. This is for strings, numbers and unset values
+        record.set(key, safe[key])
       }
     })
   })


### PR DESCRIPTION
## What it solves
Cleans up https://github.com/safe-global/safe-react/pull/3891 hotfix for fetching contract ABIs on L2 networks.

## How this PR fixes it
Manual removal of the `+L2` meta suffix has been removed, instead optining for 'cleaning' the version when getting Safe instances instead.

All places where the `currentVersion` is used have been checked, all of which lead to `getGnosisSafeInstanceAt`.

Note: we need not modify the deployments repo as it would require adding a dependency, which it currently has none of.

## How to test it
- Creating/executing transactions on L2 networks should be possible.