### PR TITLE
Fix: spending limit beneficiary address can be too long

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -25,7 +25,7 @@ const ModalStyled = styled(ModalMUI)`
   .paper {
     position: relative;
     top: 68px;
-    width: 500px;
+    width: 525px;
     border-radius: 8px;
     background-color: #ffffff;
     box-shadow: 1px 2px 10px 0 rgba(40, 54, 61, 0.18);
@@ -60,6 +60,7 @@ const ModalStyled = styled(ModalMUI)`
 
     @media (max-width: ${screenSm}px) {
       width: 100vw;
+      max-width: 100vw !important;
     }
   }
 `

--- a/src/routes/safe/components/Settings/SpendingLimit/FormFields/Beneficiary.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/FormFields/Beneficiary.tsx
@@ -14,6 +14,8 @@ import { mustBeEthereumAddress } from 'src/components/forms/validator'
 
 const BeneficiaryInput = styled.div`
   grid-area: beneficiaryInput;
+  max-width: 100%;
+  word-break: break-all;
 `
 
 const BeneficiaryScan = styled.div`

--- a/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
+++ b/src/routes/safe/components/Settings/SpendingLimit/NewLimitModal/Review.tsx
@@ -278,7 +278,7 @@ export const ReviewSpendingLimits = ({ onBack, onClose, txToken, values }: Revie
             </Text>
           )}
         </Col>
-        <Col margin="md">
+        <Col margin="md" style={{ wordBreak: 'break-all' }}>
           <AddressInfo address={values.beneficiary} title="Beneficiary" color="placeHolder" />
         </Col>
         <Col margin="md">


### PR DESCRIPTION
## What it solves
Resolves #3894

## How this PR fixes it
* Increases the modal width to 525 px (affects all tx modals)
* Makes the beneficiary field wrap to the next line on very small screens

## How to test it
* Start creating a new Spending Limit
* Reduce the window size gradually down to 600 px