### PR TITLE
Fix: fallback tx location

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/TxSingularDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSingularDetails.tsx
@@ -23,20 +23,20 @@ import FetchError from '../../FetchError'
 import useAsync from 'src/logic/hooks/useAsync'
 import { getTransactionWithLocationByAttribute } from 'src/logic/safe/store/selectors/gatewayTransactions'
 
-const useStoredTx = (txId?: string): { txLocation: TxLocation; transaction?: Transaction } => {
+const useStoredTx = (txId?: string): { txLocation: TxLocation; transaction?: Transaction } | null => {
   return (
     useSelector(
       (state: AppReduxState) =>
         txId ? getTransactionWithLocationByAttribute(state, { attributeName: 'id', attributeValue: txId }) : undefined,
       shallowEqual,
-    ) || { txLocation: 'history' }
+    ) || null
   )
 }
 
 const TxSingularDetails = (): ReactElement => {
   // Get a safeTxHash from the URL
   const { [TRANSACTION_ID_SLUG]: txId = '' } = useParams<SafeRouteSlugs>()
-  const { transaction, txLocation } = useStoredTx(txId)
+  const storedTx = useStoredTx(txId)
 
   // Fetch tx details
   const [fetchedTx, error] = useAsync<TransactionDetails>(() => fetchSafeTransaction(txId), [txId])
@@ -52,7 +52,7 @@ const TxSingularDetails = (): ReactElement => {
     )
   }
 
-  const detailedTx = transaction || (fetchedTx ? makeTxFromDetails(fetchedTx) : null)
+  const detailedTx = storedTx?.transaction || (fetchedTx ? makeTxFromDetails(fetchedTx) : null)
 
   if (!detailedTx) {
     return (
@@ -64,9 +64,10 @@ const TxSingularDetails = (): ReactElement => {
 
   const isQueue = isTxQueued(detailedTx.txStatus)
   const TxList = isQueue ? QueueTxList : HistoryTxList
+  const fallbackLocation: TxLocation = isQueue ? 'queued.queued' : 'history'
 
   return (
-    <TxLocationContext.Provider value={{ txLocation }}>
+    <TxLocationContext.Provider value={{ txLocation: storedTx?.txLocation || fallbackLocation }}>
       <TxList transactions={[[detailedTx.timestamp.toString(), [detailedTx]]]} />
     </TxLocationContext.Provider>
   )


### PR DESCRIPTION
## What it solves
@Uxio0 found a tx that doesn't show the Confirm button although it has 0 sigs.

![image (1)](https://user-images.githubusercontent.com/381895/170054690-cc5c3d59-d30a-49ee-97af-47da10388bea.png)

https://safe-team.staging.gnosisdev.com/app/rin:0x821C441214880CA8b357799c9a81c177006dA77D/transactions/0x9bfff5afb34e5c25ea340dc222c5a63324f4eff70ca76f128ce84250fe5c14d4

## How this PR fixes it
The reason the Confirm button isn't shown there is because it thinks the transaction is in the History (and thus not actionable).

It was looking up the deep-linked tx in the queue, and if it wasn't there, assumed it was in the History.
I've fixed it by falling back to the Queue instead, if the transaction is in on of the queued states (such as AWAITING_CONFIRMATIONS).

## How to test it
I wasn't able to reproduce it on dev, only on staging. So chances are, it got already fixed by some other commit.
But this fix won't hurt.