### PR TITLE
feat: Update isValidMessage() check for Safe Apps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,18 +32,6 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-  e2e:
-    runs-on: ubuntu-20.04
-    # let's make sure our tests pass on Chrome browser
-    name: E2E on Chrome
-    steps:
-      - uses: actions/checkout@v2
-      - uses: cypress-io/github-action@v2
-        with:
-          spec: cypress/integration/smoke/*.spec.js
-          browser: chrome
-          record: false
-          config: baseUrl=https://pr${{ github.event.number }}--safereact.review-safe.gnosisdev.com/app/
   deploy:
     name: Deployment
     runs-on: ubuntu-latest
@@ -175,3 +163,16 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+  e2e:
+    runs-on: ubuntu-20.04
+    # let's make sure our tests pass on Chrome browser
+    name: E2E on Chrome
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cypress-io/github-action@v2
+        with:
+          spec: cypress/integration/smoke/*.spec.js
+          browser: chrome
+          record: false
+          config: baseUrl=https://pr${{ github.event.number }}--safereact.review-safe.gnosisdev.com/app/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,9 +53,7 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: |
-            '**/node_modules'              
-            '**/.cache/Cypress'
+          path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,9 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: '**/node_modules'
+          path: |
+            '**/node_modules'              
+            '**/.cache/Cypress'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,7 +165,6 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
   e2e:
     runs-on: ubuntu-20.04
-    # let's make sure our tests pass on Chrome browser
     name: E2E on Chrome
     needs: deploy
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,18 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+  e2e:
+    runs-on: ubuntu-20.04
+    # let's make sure our tests pass on Chrome browser
+    name: E2E on Chrome
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cypress-io/github-action@v2
+        with:
+          spec: cypress/integration/smoke/*.spec.js
+          browser: chrome
+          record: false
+          config: baseUrl=https://pr${{ github.event.number }}--safereact.review-safe.gnosisdev.com/app/
   deploy:
     name: Deployment
     runs-on: ubuntu-latest
@@ -163,11 +175,3 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-
-      # Cypress E2E tests
-      - name: Cypress run
-        uses: cypress-io/github-action@v2
-        with:
-          spec: cypress/integration/smoke/*.spec.js
-          record: false
-          config: baseUrl=https://pr${{ github.event.number }}--safereact.review-safe.gnosisdev.com/app/

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -44,7 +44,7 @@ class AppCommunicator {
     }
 
     // @ts-expect-error .parent doesn't exist on some possible types
-    const sentFromIframe = msg.source.parent === window.parent
+    const sentFromIframe = msg.source.parent === window
     const knownMethod = Object.values(Methods).includes(msg.data.method)
 
     return sentFromIframe && knownMethod

--- a/src/routes/safe/components/Apps/communicator.ts
+++ b/src/routes/safe/components/Apps/communicator.ts
@@ -43,8 +43,7 @@ class AppCommunicator {
       return true
     }
 
-    // @ts-expect-error .parent doesn't exist on some possible types
-    const sentFromIframe = msg.source.parent === window
+    const sentFromIframe = this.iframeRef.current?.contentWindow === msg.source
     const knownMethod = Object.values(Methods).includes(msg.data.method)
 
     return sentFromIframe && knownMethod


### PR DESCRIPTION
## What it solves
Cypress is being executed inside an iframe so the current comparison for checking valid messages is not working inside the Cypress context

## How this PR fixes it
We are comparing the message source window against `window` instead `window.parent` as should be the same in the web context


