### PR TITLE
fix: Execute e2e only in PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,6 +166,7 @@ jobs:
   e2e:
     runs-on: ubuntu-20.04
     name: E2E on Chrome
+    if: github.event.number
     needs: deploy
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## What it solves
Execute smoke tests only in PRs
