### PR TITLE
Feat: show NFT apps on the NFT page

### DIFF
--- a/src/components/InfoAlert/index.tsx
+++ b/src/components/InfoAlert/index.tsx
@@ -6,11 +6,11 @@ import { ReactElement } from 'react'
 type InfoAlertProps = {
   title: string
   text: string
-  key: string
+  id: string
 }
 
 const InfoAlert = (props: InfoAlertProps): ReactElement | null => {
-  const [isClosed, setClosed] = useCachedState<boolean>(props.key)
+  const [isClosed, setClosed] = useCachedState<boolean>(`${props.id}Closed`)
 
   return isClosed ? null : (
     <MuiAlert severity="info" onClose={() => setClosed(true)} style={{ marginBottom: '26px' }}>

--- a/src/components/InfoAlert/index.tsx
+++ b/src/components/InfoAlert/index.tsx
@@ -1,0 +1,24 @@
+import MuiAlert from '@material-ui/lab/Alert'
+import useCachedState from 'src/utils/storage/useCachedState'
+import Paragraph from 'src/components/layout/Paragraph'
+import { ReactElement } from 'react'
+
+type InfoAlertProps = {
+  title: string
+  text: string
+  key: string
+}
+
+const InfoAlert = (props: InfoAlertProps): ReactElement | null => {
+  const [isClosed, setClosed] = useCachedState<boolean>(props.key)
+
+  return isClosed ? null : (
+    <MuiAlert severity="info" onClose={() => setClosed(true)} style={{ marginBottom: '26px' }}>
+      <Paragraph style={{ fontWeight: 'bold', margin: '0 0 0.5em' }}>{props.title}</Paragraph>
+
+      <Paragraph noMargin>{props.text}</Paragraph>
+    </MuiAlert>
+  )
+}
+
+export default InfoAlert

--- a/src/components/InfoAlert/index.tsx
+++ b/src/components/InfoAlert/index.tsx
@@ -13,7 +13,7 @@ const InfoAlert = (props: InfoAlertProps): ReactElement | null => {
   const [isClosed, setClosed] = useCachedState<boolean>(`${props.id}Closed`)
 
   return isClosed ? null : (
-    <MuiAlert severity="info" onClose={() => setClosed(true)} style={{ marginBottom: '26px' }}>
+    <MuiAlert severity="info" onClose={() => setClosed(true)} style={{ margin: '0 20px 26px 0' }}>
       <Paragraph style={{ fontWeight: 'bold', margin: '0 0 0.5em' }}>{props.title}</Paragraph>
 
       <Paragraph noMargin>{props.text}</Paragraph>

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -181,15 +181,19 @@ const CollectiblesPage = (): React.ReactElement => {
     <Collectibles>
       {infoBar}
 
-      <h3>NFT apps</h3>
+      {nftApps.length > 0 && (
+        <>
+          <h3>NFT apps</h3>
 
-      <Grid style={{ marginBottom: '30px' }}>
-        {nftApps.map((app) => (
-          <Grid item key={app.id} xs={4}>
-            <SafeAppCard safeApp={app} size="md" togglePin={togglePin} />
+          <Grid style={{ marginBottom: '30px' }}>
+            {nftApps.map((app) => (
+              <Grid item key={app.id} xs={4}>
+                <SafeAppCard safeApp={app} size="md" togglePin={togglePin} />
+              </Grid>
+            ))}
           </Grid>
-        ))}
-      </Grid>
+        </>
+      )}
 
       <h3>NFTs</h3>
     </Collectibles>

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -105,12 +105,10 @@ const Collectibles = ({ children }: { children: ReactNode }): React.ReactElement
     setSendNFTsModalOpen(true)
   }
 
-  const intro = <Fragment key="intro">{children}</Fragment>
-
   if (nftAssetsFromNftTokens.length === 0) {
     return (
       <Fragment>
-        {intro}
+        {children}
         <Card className={classes.cardOuter}>
           <div className={classes.cardInner}>
             <Paragraph className={classes.noData}>{nftLoaded ? 'No NFTs available' : 'Loading NFTs...'}</Paragraph>
@@ -132,7 +130,7 @@ const Collectibles = ({ children }: { children: ReactNode }): React.ReactElement
 
           return (
             <Fragment key={nftAsset.slug}>
-              {index === 0 && intro}
+              {index === 0 && children}
 
               <div className={classes.title}>
                 <div className={classes.titleImg} style={{ backgroundImage: `url(${nftAsset.image || ''})` }} />

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -2,9 +2,9 @@ import { Fragment, useEffect, useMemo, useState } from 'react'
 import Card from '@material-ui/core/Card'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import { useSelector } from 'react-redux'
+import { Grid } from '@material-ui/core'
 
 import Item from './components/Item'
-
 import Paragraph from 'src/components/layout/Paragraph'
 import {
   nftAssetsFromNftTokensSelector,
@@ -17,6 +17,9 @@ import { NFTToken } from 'src/logic/collectibles/sources/collectibles.d'
 import { trackEvent } from 'src/utils/googleTagManager'
 import { ASSETS_EVENTS } from 'src/utils/events/assets'
 import VirtualizedList from 'src/components/VirtualizedList'
+import InfoAlert from 'src/components/InfoAlert'
+import SafeAppCard from '../../Apps/components/SafeAppCard/SafeAppCard'
+import { useAppList } from '../../Apps/hooks/appList/useAppList'
 
 const useStyles = makeStyles(
   createStyles({
@@ -154,4 +157,38 @@ const Collectibles = (): React.ReactElement => {
   )
 }
 
-export default Collectibles
+const CollectiblesPage = (): React.ReactElement => {
+  const NFT_APPS_TAG = 'nft'
+  const { allApps, togglePin } = useAppList()
+  const nftApps = useMemo(() => allApps.filter((app) => app.tags?.includes(NFT_APPS_TAG)), [allApps])
+
+  const infoBar = (
+    <InfoAlert
+      key="collectiblesInfoClosed"
+      title="Use Safe Apps to view your NFT portfolio"
+      text="Get the most optimal experience with Safe Apps. View your collections, buy or sell NFTs, and more."
+    />
+  )
+
+  return (
+    <div>
+      {infoBar}
+
+      <h3>NFT apps</h3>
+
+      <Grid style={{ marginBottom: '30px' }}>
+        {nftApps.map((app) => (
+          <Grid item key={app.id} xs={4}>
+            <SafeAppCard safeApp={app} size="md" togglePin={togglePin} />
+          </Grid>
+        ))}
+      </Grid>
+
+      <h3>NFTs</h3>
+
+      <Collectibles />
+    </div>
+  )
+}
+
+export default CollectiblesPage

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from 'react'
+import { Fragment, ReactNode, useEffect, useMemo, useState } from 'react'
 import Card from '@material-ui/core/Card'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import { useSelector } from 'react-redux'
@@ -86,7 +86,7 @@ const useStyles = makeStyles(
   }),
 )
 
-const Collectibles = (): React.ReactElement => {
+const Collectibles = ({ children }: { children: ReactNode }): React.ReactElement => {
   const classes = useStyles()
   const [selectedToken, setSelectedToken] = useState<NFTToken | undefined>()
   const [sendNFTsModalOpen, setSendNFTsModalOpen] = useState(false)
@@ -105,13 +105,18 @@ const Collectibles = (): React.ReactElement => {
     setSendNFTsModalOpen(true)
   }
 
+  const intro = <Fragment key="intro">{children}</Fragment>
+
   if (nftAssetsFromNftTokens.length === 0) {
     return (
-      <Card className={classes.cardOuter}>
-        <div className={classes.cardInner}>
-          <Paragraph className={classes.noData}>{nftLoaded ? 'No NFTs available' : 'Loading NFTs...'}</Paragraph>
-        </div>
-      </Card>
+      <Fragment>
+        {intro}
+        <Card className={classes.cardOuter}>
+          <div className={classes.cardInner}>
+            <Paragraph className={classes.noData}>{nftLoaded ? 'No NFTs available' : 'Loading NFTs...'}</Paragraph>
+          </div>
+        </Card>
+      </Fragment>
     )
   }
 
@@ -119,7 +124,7 @@ const Collectibles = (): React.ReactElement => {
     <>
       <VirtualizedList
         data={nftAssetsFromNftTokens}
-        itemContent={(_, nftAsset) => {
+        itemContent={(index, nftAsset) => {
           // Larger collectible lists can cause this to be initially undefined
           if (!nftAsset) {
             return null
@@ -127,6 +132,8 @@ const Collectibles = (): React.ReactElement => {
 
           return (
             <Fragment key={nftAsset.slug}>
+              {index === 0 && intro}
+
               <div className={classes.title}>
                 <div className={classes.titleImg} style={{ backgroundImage: `url(${nftAsset.image || ''})` }} />
                 <h2 className={classes.titleText}>{nftAsset.name}</h2>
@@ -171,7 +178,7 @@ const CollectiblesPage = (): React.ReactElement => {
   )
 
   return (
-    <div>
+    <Collectibles>
       {infoBar}
 
       <h3>NFT apps</h3>
@@ -185,9 +192,7 @@ const CollectiblesPage = (): React.ReactElement => {
       </Grid>
 
       <h3>NFTs</h3>
-
-      <Collectibles />
-    </div>
+    </Collectibles>
   )
 }
 

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -177,10 +177,10 @@ const CollectiblesPage = (): React.ReactElement => {
 
   return (
     <Collectibles>
-      {infoBar}
-
       {nftApps.length > 0 && (
         <>
+          {infoBar}
+
           <h3>NFT apps</h3>
 
           <Grid style={{ marginBottom: '30px' }}>

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -164,7 +164,7 @@ const CollectiblesPage = (): React.ReactElement => {
 
   const infoBar = (
     <InfoAlert
-      key="collectiblesInfoClosed"
+      id="collectiblesInfo"
       title="Use Safe Apps to view your NFT portfolio"
       text="Get the most optimal experience with Safe Apps. View your collections, buy or sell NFTs, and more."
     />

--- a/src/routes/safe/components/Balances/Collectibles/index.tsx
+++ b/src/routes/safe/components/Balances/Collectibles/index.tsx
@@ -164,7 +164,7 @@ const Collectibles = ({ children }: { children: ReactNode }): React.ReactElement
 
 const CollectiblesPage = (): React.ReactElement => {
   const NFT_APPS_TAG = 'nft'
-  const { allApps, togglePin } = useAppList()
+  const { allApps, pinnedSafeApps, togglePin } = useAppList()
   const nftApps = useMemo(() => allApps.filter((app) => app.tags?.includes(NFT_APPS_TAG)), [allApps])
 
   const infoBar = (
@@ -186,7 +186,12 @@ const CollectiblesPage = (): React.ReactElement => {
           <Grid style={{ marginBottom: '30px' }}>
             {nftApps.map((app) => (
               <Grid item key={app.id} xs={4}>
-                <SafeAppCard safeApp={app} size="md" togglePin={togglePin} />
+                <SafeAppCard
+                  safeApp={app}
+                  size="md"
+                  togglePin={togglePin}
+                  isPinned={pinnedSafeApps.some(({ id }) => id === app.id)}
+                />
               </Grid>
             ))}
           </Grid>

--- a/src/theme/mui.ts
+++ b/src/theme/mui.ts
@@ -28,6 +28,7 @@ import {
   xs,
   black300,
   black400,
+  infoColor,
 } from './variables'
 
 const palette = {
@@ -504,11 +505,17 @@ const theme = createTheme({
     MuiAlert: {
       root: {
         color: fontColor,
-        height: '48px',
         alignItems: 'center',
       },
       standardWarning: {
         backgroundColor: alertWarning,
+      },
+      standardInfo: {
+        backgroundColor: infoColor,
+        borderRadius: '8px',
+        '& svg': {
+          color: secondary,
+        },
       },
       icon: {
         '& > svg': {

--- a/src/theme/variables.js
+++ b/src/theme/variables.js
@@ -17,6 +17,7 @@ const secondaryBackground = '#f0efee'
 const sm = '8px'
 const warningColor = '#ffc05f'
 const alertWarningColor = '#FBE5C5'
+const infoColor = '#ECF5F4'
 const xl = '32px'
 const xs = '4px'
 const xxl = '40px'
@@ -63,6 +64,7 @@ module.exports = {
   primary200: primaryLite,
   primary300: '#92C9BE',
   primary400: primaryActive,
+  infoColor,
   regularFont: 400,
   red400: '#C31717',
   screenLg: 1200,


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-pm/issues/57

## How this PR fixes it
* Adds an info bar
* Shows the Safe Apps tagged with `nft` on the NFTs page

## How to test it
- Open the collectibles page
- Close the info bar
- Refresh the page – the info bar should not be displayed again

## Analytics changes
We should probably track clicks on the apps?

## Screenshots
<img width="879" alt="Screenshot 2022-05-25 at 15 33 28" src="https://user-images.githubusercontent.com/381895/170274597-7b12cecb-bfed-4209-8b0a-a93a0eee79c9.png">
