### PR TITLE
Hotfix: remove GTM allowlist 🔥 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.25.4",
+  "version": "3.25.5",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/utils/__tests__/googleTagManager.test.tsx
+++ b/src/utils/__tests__/googleTagManager.test.tsx
@@ -117,7 +117,6 @@ describe('googleTagManager', () => {
         auth: 'auth123',
         preview: 'env-3',
         dataLayer: {
-          'gtm.allowlist': ['gaawc', 'gaawe'],
           'gtm.blocklist': ['j', 'jsm', 'customScripts'],
           event: 'pageview',
           chainId: '4',

--- a/src/utils/googleTagManager.ts
+++ b/src/utils/googleTagManager.ts
@@ -86,10 +86,8 @@ export const loadGoogleTagManager = (): void => {
       event: GTM_EVENT.PAGEVIEW,
       chainId: _getChainId(),
       page,
-      // Allow only GA4 configuration and GA4 custom event tags
-      // @see https://developers.google.com/tag-platform/tag-manager/web/restrict
-      'gtm.allowlist': ['gaawc', 'gaawe'],
       // Block JS variables and custom scripts
+      // @see https://developers.google.com/tag-platform/tag-manager/web/restrict
       'gtm.blocklist': ['j', 'jsm', 'customScripts'],
     },
   })


### PR DESCRIPTION
## What it solves
As Usame discovered in #3913, after #3807, custom events seem to have been broken.

<img width="651" alt="Screenshot 2022-05-27 at 11 04 58" src="https://user-images.githubusercontent.com/381895/170668411-11d99b07-aad3-477f-83be-997f151a188d.png">

## How this PR fixes it
Removes the GTM allowlist and keeps only the blocklist.

## How to test it
Needs to be tested with a production build, so that we can verify that the events are actually sent to GA.