### PR TITLE
feat: Show compatible Safes from localstorage when a wallet has not been connected

### DIFF
--- a/src/routes/SafeAppLandingPage/SafeAppLandingPage.tsx
+++ b/src/routes/SafeAppLandingPage/SafeAppLandingPage.tsx
@@ -89,12 +89,13 @@ const SafeAppLandingPage = (): ReactElement => {
 
             <ActionsContainer>
               {/* User Safe Section */}
-              <UserSafeSection
-                safeAppUrl={safeAppUrl}
-                availableChains={availableChains}
-                safeAppChainId={safeAppChainId}
-              />
-
+              {safeAppChainId && (
+                <UserSafeSection
+                  safeAppUrl={safeAppUrl}
+                  availableChains={availableChains}
+                  safeAppChainId={safeAppChainId}
+                />
+              )}
               {/* Demo Safe Section */}
               <TryDemoSafe safeAppUrl={safeAppUrl} />
             </ActionsContainer>

--- a/src/routes/SafeAppLandingPage/components/UserSafeSection.tsx
+++ b/src/routes/SafeAppLandingPage/components/UserSafeSection.tsx
@@ -19,6 +19,43 @@ type UserSafeProps = {
   safeAppChainId: string
 }
 
+const getCompatibleSafesFromLocalStorage = (
+  safesFromService: Record<string, string[]>,
+  safesFromLocalStorage: LocalSafes,
+  compatibleChains: string[],
+  addressBook: AddressBookEntry[],
+): AddressBookEntry[] => {
+  return compatibleChains.reduce((compatibleSafes, chainId) => {
+    const safesFromLocalstorage =
+      safesFromLocalStorage[chainId]
+        ?.filter(({ address }) => !safesFromService[chainId]?.includes(address)) // we filter Safes already included
+        ?.map(({ address }) => ({
+          address,
+          chainId,
+          name: getNameFromAddressBook(addressBook, address, chainId),
+        })) || []
+
+    return [...compatibleSafes, ...safesFromLocalstorage]
+  }, [])
+}
+
+const getCompatibleSafesFromService = (
+  safesFromService: Record<string, string[]>,
+  compatibleChains: string[],
+  addressBook: AddressBookEntry[],
+): AddressBookEntry[] => {
+  return compatibleChains.reduce((compatibleSafes, chainId) => {
+    const safesFromConfigService =
+      safesFromService[chainId]?.map((address) => ({
+        address,
+        chainId,
+        name: getNameFromAddressBook(addressBook, address, chainId),
+      })) || []
+
+    return [...compatibleSafes, ...safesFromConfigService]
+  }, [])
+}
+
 const UserSafeSection = ({ safeAppUrl, availableChains, safeAppChainId }: UserSafeProps): ReactElement => {
   const userAddress = useSelector(userAccountSelector)
   const lastViewedSafeAddress = useSelector(lastViewedSafe)
@@ -86,43 +123,6 @@ const ConnectWalletContainer = styled.div`
 const ConnectWalletButton = styled(ConnectButton)`
   height: 52px;
 `
-
-const getCompatibleSafesFromLocalStorage = (
-  safesFromService: Record<string, string[]>,
-  safesFromLocalStorage: LocalSafes,
-  compatibleChains: string[],
-  addressBook: AddressBookEntry[],
-): AddressBookEntry[] => {
-  return compatibleChains.reduce((compatibleSafes, chainId) => {
-    const safesFromLocalstorage =
-      safesFromLocalStorage[chainId]
-        ?.filter(({ address }) => !safesFromService[chainId]?.includes(address)) // we filter Safes already included
-        ?.map(({ address }) => ({
-          address,
-          chainId,
-          name: getNameFromAddressBook(addressBook, address, chainId),
-        })) || []
-
-    return [...compatibleSafes, ...safesFromLocalstorage]
-  }, [])
-}
-
-const getCompatibleSafesFromService = (
-  safesFromService: Record<string, string[]>,
-  compatibleChains: string[],
-  addressBook: AddressBookEntry[],
-): AddressBookEntry[] => {
-  return compatibleChains.reduce((compatibleSafes, chainId) => {
-    const safesFromConfigService =
-      safesFromService[chainId]?.map((address) => ({
-        address,
-        chainId,
-        name: getNameFromAddressBook(addressBook, address, chainId),
-      })) || []
-
-    return [...compatibleSafes, ...safesFromConfigService]
-  }, [])
-}
 
 const getNameFromAddressBook = (addressBook: AddressBookEntry[], address: string, chainId: string) => {
   const addressBookEntry = addressBook.find(

--- a/src/routes/SafeAppLandingPage/components/UserSafeSection.tsx
+++ b/src/routes/SafeAppLandingPage/components/UserSafeSection.tsx
@@ -27,7 +27,7 @@ const getCompatibleSafes = (
   addressBook: AddressBookEntry[],
 ): AddressBookEntry[] => {
   return compatibleChains.reduce((result, chainId) => {
-    const flatSafesFromLocalStorage = safesFromLocalStorage[chainId].map(({ address }) => address) || []
+    const flatSafesFromLocalStorage = safesFromLocalStorage[chainId]?.map(({ address }) => address) || []
     const flatSafesFromService = safesFromService[chainId] || []
 
     // we remove duplicated safes


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/safe-react-apps/issues/446

## How this PR fixes it

Now we only show  the "connect wallet" button if the wallet has not been connected and there are no compatible Safes present in the localstorage:

```
  const isWalletConnected = !!userAddress
  const hasComplatibleSafes = compatibleSafes.length > 0

  const showConnectWalletSection = !isWalletConnected && !hasComplatibleSafes
```

## How to test it

go to 
```
https://pr3924--safereact.review-safe.gnosisdev.com/app/share/safe-app?appUrl=https://safe-apps.dev.gnosisdev.com/tx-builder&chainId=4
```

- If the wallet has not been connected and there are no compatible Safes present in the localstorage, we show the "connect wallet" button.
- If the wallet has not been connected and there ara compatible Safes present in the localstorage, we show the safe selector.


## Screenshots

![Captura de pantalla 2022-05-27 a las 16 12 08](https://user-images.githubusercontent.com/26763673/170719798-245530f1-36f6-4d84-9b5d-f3c712e3bdef.png)

