### PR TITLE
feat: add support for unstoppable domains minted on polygon

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "@openzeppelin/contracts": "4.4.2",
     "@sentry/react": "^6.10.0",
     "@sentry/tracing": "^6.10.0",
-    "@unstoppabledomains/resolution": "^1.17.0",
+    "@truffle/hdwallet-provider": "^2.0.8",
+    "@unstoppabledomains/resolution": "^7.1.4",
     "abi-decoder": "^2.4.0",
     "axios": "0.21.4",
     "bignumber.js": "9.0.1",
@@ -138,8 +139,7 @@
     "web3": "1.7.0",
     "web3-core": "^1.7.0",
     "web3-eth-contract": "^1.7.0",
-    "web3-utils": "^1.7.0",
-    "@truffle/hdwallet-provider": "^2.0.8"
+    "web3-utils": "^1.7.0"
   },
   "devDependencies": {
     "@gnosis.pm/safe-core-sdk-types": "1.0.0",

--- a/src/logic/wallets/ethAddresses.ts
+++ b/src/logic/wallets/ethAddresses.ts
@@ -48,4 +48,5 @@ export const isUserAnOwnerOfAnySafe = (safes: List<SafeRecord> | SafeRecord[], u
 
 export const isValidEnsName = (name: string): boolean => /^([\w-]+\.)+(eth|test|xyz|luxe|ewc)$/.test(name)
 
-export const isValidCryptoDomainName = (name: string): boolean => /^([\w-]+\.)+(crypto)$/.test(name)
+export const isValidCryptoDomainName = (name: string): boolean =>
+  /^([\w-]+\.)+(crypto|nft|x|wallet|bitcoin|dao|888|coin)$/.test(name)

--- a/src/logic/wallets/utils/unstoppableDomains.ts
+++ b/src/logic/wallets/utils/unstoppableDomains.ts
@@ -1,5 +1,4 @@
 import UnstoppableResolution from '@unstoppabledomains/resolution'
-import { getRpcServiceUrl } from 'src/config'
 
 let UDResolution: UnstoppableResolution
 
@@ -9,10 +8,10 @@ export const getAddressFromUnstoppableDomain = (name: string): Promise<string> =
       sourceConfig: {
         uns: {
           api: true,
-          url: getRpcServiceUrl(),
         },
       },
     })
   }
-  return UDResolution.addr(name, 'ETH')
+  const resolved = UDResolution.addr(name, 'ETH')
+  return resolved
 }

--- a/src/logic/wallets/utils/unstoppableDomains.ts
+++ b/src/logic/wallets/utils/unstoppableDomains.ts
@@ -1,18 +1,18 @@
 import UnstoppableResolution from '@unstoppabledomains/resolution'
 import { getRpcServiceUrl } from 'src/config'
 
-let unstoppableResolver: UnstoppableResolution
+let UDResolution: UnstoppableResolution
 
 export const getAddressFromUnstoppableDomain = (name: string): Promise<string> => {
-  if (!unstoppableResolver) {
-    unstoppableResolver = new UnstoppableResolution({
-      blockchain: {
-        cns: {
+  if (!UDResolution) {
+    UDResolution = new UnstoppableResolution({
+      sourceConfig: {
+        uns: {
+          api: true,
           url: getRpcServiceUrl(),
         },
       },
     })
   }
-
-  return unstoppableResolver.addr(name, 'ETH')
+  return UDResolution.addr(name, 'ETH')
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,21 +1333,6 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
-"@ensdomains/address-encoder@0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@ensdomains/address-encoder/-/address-encoder-0.2.6.tgz#1ea4aefea8c9617ada0a80519bec00589920ffac"
-  integrity sha512-b0jtq3vx1xxUJRwS9zJMy5SVtH1ixIS18gHm3tFyBR1ehsk/lK80nCoV1lJi0KXgQ/2RD+/KYoWlW5CNZG7AAw==
-  dependencies:
-    bech32 "^1.1.3"
-    blakejs "^1.1.0"
-    bn.js "^4.11.8"
-    bs58 "^4.0.1"
-    crypto-addr-codec "^0.1.7"
-    js-sha512 "^0.8.0"
-    nano-base32 "^1.0.1"
-    ripemd160 "^2.0.2"
-    sha3 "^2.1.3"
-
 "@ensdomains/address-encoder@^0.1.7":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@ensdomains/address-encoder/-/address-encoder-0.1.9.tgz#f948c485443d9ef7ed2c0c4790e931c33334d02d"
@@ -3604,23 +3589,17 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@unstoppabledomains/resolution@^1.17.0":
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-1.20.0.tgz#b1a8707b18359e98e4b352a7905e70a182f6eaa0"
-  integrity sha512-UZva7Pi6PrCX+6KsTZKy0hM4fKBny6a2hJ7jgu6zo0+zmtlYe/SjmQN3Asn5RBUm931eB3aI4UN7Kysw+rJ5RQ==
+"@unstoppabledomains/resolution@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-7.1.4.tgz#f3f0f9d2f36b88bf0a3af92c26731a01e5dba94b"
+  integrity sha512-GdXLpP+oRk4lLWMISo7g7gPyKoCONyLoQtYH6GVhXtyY9t+CeHJW2kZ/btcbXg0lmEO6PSr5yYOlDz4wRCq2RA==
   dependencies:
-    "@ensdomains/address-encoder" "0.2.6"
     "@ethersproject/abi" "^5.0.1"
-    bip44-constants "^8.0.5"
     bn.js "^4.4.0"
-    commander "^4.1.1"
-    content-hash "^2.5.2"
-    ethereum-ens-network-map "^1.0.2"
-    hash.js "^1.1.7"
+    cross-fetch "^3.1.4"
+    elliptic "^6.5.4"
+    js-sha256 "^0.9.0"
     js-sha3 "^0.8.0"
-    node-fetch "^2.6.0"
-  optionalDependencies:
-    dotenv "^8.2.0"
 
 "@virtuoso.dev/react-urx@^0.2.12":
   version "0.2.13"
@@ -4935,11 +4914,6 @@ bip39@^3.0.2:
     create-hash "^1.1.0"
     pbkdf2 "^3.0.9"
     randombytes "^2.0.1"
-
-bip44-constants@^8.0.5:
-  version "8.0.103"
-  resolved "https://registry.yarnpkg.com/bip44-constants/-/bip44-constants-8.0.103.tgz#fc8c6718a2d8f38bf7fdb689732250e32333ba8b"
-  integrity sha512-wuGsY9IKUS9GC5Sf/Acb5jLJZI3Z8qsMoQHWldnQyoVUlij4y8e5srh28Iqul1HwK+elPsAYGNYKtYhovjvNxA==
 
 bip66@^1.1.5:
   version "1.1.5"
@@ -6300,7 +6274,7 @@ cross-fetch@^2.1.0:
     node-fetch "^2.6.7"
     whatwg-fetch "^2.0.4"
 
-cross-fetch@^3.1.5:
+cross-fetch@^3.1.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -7156,11 +7130,6 @@ dotenv@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
-
-dotenv@^8.2.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
-  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
 drbg.js@^1.0.1:
   version "1.0.1"
@@ -8066,11 +8035,6 @@ ethereum-cryptography@^0.1.3:
     scrypt-js "^3.0.0"
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
-
-ethereum-ens-network-map@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ethereum-ens-network-map/-/ethereum-ens-network-map-1.0.2.tgz#4e27bad18dae7bd95d84edbcac2c9e739fc959b9"
-  integrity sha512-5qwJ5n3YhjSpE6O/WEBXCAb2nagUgyagJ6C0lGUBWC4LjKp/rRzD+pwtDJ6KCiITFEAoX4eIrWOjRy0Sylq5Hg==
 
 ethereum-private-key-to-address@0.0.3:
   version "0.0.3"
@@ -11152,7 +11116,7 @@ js-cookie@^3.0.0:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
   integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
-js-sha256@0.9.0:
+js-sha256@0.9.0, js-sha256@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
   integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
@@ -11166,11 +11130,6 @@ js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
-
-js-sha512@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/js-sha512/-/js-sha512-0.8.0.tgz#dd22db8d02756faccf19f218e3ed61ec8249f7d4"
-  integrity sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -16018,7 +15977,7 @@ sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-sha3@^2.1.1, sha3@^2.1.3:
+sha3@^2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/sha3/-/sha3-2.1.4.tgz#000fac0fe7c2feac1f48a25e7a31b52a6492cc8f"
   integrity sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==


### PR DESCRIPTION
## What it solves
Resolves #3831 

## How this PR fixes it
- update @unstoppabledomains/resolution to use the latest version (in package.json)
- modify address resolution function to use new version (in src/logic/wallets/utils/unstoppableDomains.ts)
- add .nft, .x, .wallet, .bitcoin, .dao, .888, .coin as valid crypto domain names (in src/logic/wallets/ethAddresses.ts)

## How to test it
- go to address book and add UD addresses with new extensions
- write new UD extension names to the transaction sending input field

## Video
[IPFS Link](https://bafybeidhvtym6rxsicto3bdtehzisb55tbsci6gkqltizbgtqa2k4huplu.ipfs.dweb.link/ud-resolve.mp4)
