### PR TITLE
fix: remove `+L2` hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@gnosis.pm/safe-apps-sdk": "7.3.0",
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-core-sdk": "^2.0.0",
-    "@gnosis.pm/safe-deployments": "^1.8.0",
+    "@gnosis.pm/safe-deployments": "^1.15.0",
     "@gnosis.pm/safe-modules-deployments": "^1.0.0",
     "@gnosis.pm/safe-react-components": "^1.1.2",
     "@gnosis.pm/safe-react-gateway-sdk": "^3.0.1",

--- a/src/logic/safe/store/reducer/safe.ts
+++ b/src/logic/safe/store/reducer/safe.ts
@@ -53,13 +53,8 @@ const updateSafeProps = (prevSafe, safe) => {
             : record.update(key, (current) => current.merge(safe[key]))
         }
       } else {
-        // Temp fix
-        if (key === 'currentVersion' && safe[key].endsWith('+L2')) {
-          record.set(key, safe[key].replace('+L2', ''))
-        } else {
-          // By default we overwrite the value. This is for strings, numbers and unset values
-          record.set(key, safe[key])
-        }
+        // By default we overwrite the value. This is for strings, numbers and unset values
+        record.set(key, safe[key])
       }
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1867,6 +1867,13 @@
     semver "^7.3.5"
     web3-utils "^1.7.0"
 
+"@gnosis.pm/safe-deployments@^1.15.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.15.0.tgz#71ed9a37437a3080443c49aa65308f2d8839d751"
+  integrity sha512-twfC5HNuj+TKS2gOowf6A1FGZfOLBHAV2JhYpmOCf2MKsfcG+Fe4TrSRgQg605MhWdwFiaGVpNkcwjvpxhGuew==
+  dependencies:
+    semver "^7.3.7"
+
 "@gnosis.pm/safe-deployments@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.8.0.tgz#856c15517274f924539ea4df40fffe6f009249a7"
@@ -15895,6 +15902,13 @@ semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
## What it solves
Reverts https://github.com/safe-global/safe-react/pull/3891 changes

## How this PR fixes it
Version metadata is now handled by `safe-deployments` and we can therefore remove this hotfix.

## How to test it
Any process involved the mastercopy of L2/Circles Safes should be tested; executing a transaction, upgrading the Safe, etc.