### PR TITLE
fix: Disable submit button while gas estimation is pending

### DIFF
--- a/src/logic/hooks/__tests__/useExecutionStatus.test.ts
+++ b/src/logic/hooks/__tests__/useExecutionStatus.test.ts
@@ -9,7 +9,16 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit, '10', '2'))
+    const { result } = renderHook(() =>
+      useExecutionStatus({
+        checkTxExecution: mockFn,
+        isExecution: true,
+        txData: EMPTY_DATA,
+        gasLimit: mockGasLimit,
+        gasPrice: '10',
+        gasMaxPrioFee: '2',
+      }),
+    )
 
     expect(result.current).toBe(EstimationStatus.LOADING)
   })
@@ -17,7 +26,16 @@ describe('useExecutionStatus', () => {
   it('returns LOADING if no gasLimit exists', async () => {
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, undefined, '10', '2'))
+    const { result } = renderHook(() =>
+      useExecutionStatus({
+        checkTxExecution: mockFn,
+        isExecution: true,
+        txData: EMPTY_DATA,
+        gasLimit: undefined,
+        gasPrice: '10',
+        gasMaxPrioFee: '2',
+      }),
+    )
 
     await waitFor(() => {
       expect(result.current).toBe(EstimationStatus.LOADING)
@@ -28,7 +46,16 @@ describe('useExecutionStatus', () => {
   it('returns LOADING if gasLimit is 0', async () => {
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, '0', '10', '2'))
+    const { result } = renderHook(() =>
+      useExecutionStatus({
+        checkTxExecution: mockFn,
+        isExecution: true,
+        txData: EMPTY_DATA,
+        gasLimit: '0',
+        gasPrice: '10',
+        gasMaxPrioFee: '2',
+      }),
+    )
 
     await waitFor(() => {
       expect(result.current).toBe(EstimationStatus.LOADING)
@@ -40,7 +67,16 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit, '0', '2'))
+    const { result } = renderHook(() =>
+      useExecutionStatus({
+        checkTxExecution: mockFn,
+        isExecution: true,
+        txData: EMPTY_DATA,
+        gasLimit: mockGasLimit,
+        gasPrice: '0',
+        gasMaxPrioFee: '2',
+      }),
+    )
 
     await waitFor(() => {
       expect(result.current).toBe(EstimationStatus.LOADING)
@@ -52,7 +88,16 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit, '10', '0'))
+    const { result } = renderHook(() =>
+      useExecutionStatus({
+        checkTxExecution: mockFn,
+        isExecution: true,
+        txData: EMPTY_DATA,
+        gasLimit: mockGasLimit,
+        gasPrice: '10',
+        gasMaxPrioFee: '0',
+      }),
+    )
 
     await waitFor(() => {
       expect(result.current).toBe(EstimationStatus.LOADING)
@@ -64,7 +109,16 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit, '10', '2'))
+    const { result } = renderHook(() =>
+      useExecutionStatus({
+        checkTxExecution: mockFn,
+        isExecution: true,
+        txData: EMPTY_DATA,
+        gasLimit: mockGasLimit,
+        gasPrice: '10',
+        gasMaxPrioFee: '2',
+      }),
+    )
 
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledTimes(1)
@@ -76,7 +130,16 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, false, EMPTY_DATA, mockGasLimit, '10', '2'))
+    const { result } = renderHook(() =>
+      useExecutionStatus({
+        checkTxExecution: mockFn,
+        isExecution: false,
+        txData: EMPTY_DATA,
+        gasLimit: mockGasLimit,
+        gasPrice: '10',
+        gasMaxPrioFee: '2',
+      }),
+    )
 
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledTimes(0)
@@ -88,7 +151,16 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, '', mockGasLimit, '10', '2'))
+    const { result } = renderHook(() =>
+      useExecutionStatus({
+        checkTxExecution: mockFn,
+        isExecution: true,
+        txData: '',
+        gasLimit: mockGasLimit,
+        gasPrice: '10',
+        gasMaxPrioFee: '2',
+      }),
+    )
 
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledTimes(0)
@@ -100,7 +172,16 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(false))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit, '10', '2'))
+    const { result } = renderHook(() =>
+      useExecutionStatus({
+        checkTxExecution: mockFn,
+        isExecution: true,
+        txData: EMPTY_DATA,
+        gasLimit: mockGasLimit,
+        gasPrice: '10',
+        gasMaxPrioFee: '2',
+      }),
+    )
 
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledTimes(1)

--- a/src/logic/hooks/__tests__/useExecutionStatus.test.ts
+++ b/src/logic/hooks/__tests__/useExecutionStatus.test.ts
@@ -9,7 +9,7 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit))
+    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit, '10', '2'))
 
     expect(result.current).toBe(EstimationStatus.LOADING)
   })
@@ -17,7 +17,42 @@ describe('useExecutionStatus', () => {
   it('returns LOADING if no gasLimit exists', async () => {
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, undefined))
+    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, undefined, '10', '2'))
+
+    await waitFor(() => {
+      expect(result.current).toBe(EstimationStatus.LOADING)
+      expect(mockFn).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  it('returns LOADING if gasLimit is 0', async () => {
+    const mockFn = jest.fn(() => Promise.resolve(true))
+
+    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, '0', '10', '2'))
+
+    await waitFor(() => {
+      expect(result.current).toBe(EstimationStatus.LOADING)
+      expect(mockFn).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  it('returns LOADING if gasPrice is 0', async () => {
+    const mockGasLimit = '21000'
+    const mockFn = jest.fn(() => Promise.resolve(true))
+
+    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit, '0', '2'))
+
+    await waitFor(() => {
+      expect(result.current).toBe(EstimationStatus.LOADING)
+      expect(mockFn).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  it('returns LOADING if gasMaxPrioFee is 0', async () => {
+    const mockGasLimit = '21000'
+    const mockFn = jest.fn(() => Promise.resolve(true))
+
+    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit, '10', '0'))
 
     await waitFor(() => {
       expect(result.current).toBe(EstimationStatus.LOADING)
@@ -29,7 +64,7 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit))
+    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit, '10', '2'))
 
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledTimes(1)
@@ -41,7 +76,7 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, false, EMPTY_DATA, mockGasLimit))
+    const { result } = renderHook(() => useExecutionStatus(mockFn, false, EMPTY_DATA, mockGasLimit, '10', '2'))
 
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledTimes(0)
@@ -53,7 +88,7 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(true))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, '', mockGasLimit))
+    const { result } = renderHook(() => useExecutionStatus(mockFn, true, '', mockGasLimit, '10', '2'))
 
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledTimes(0)
@@ -65,7 +100,7 @@ describe('useExecutionStatus', () => {
     const mockGasLimit = '21000'
     const mockFn = jest.fn(() => Promise.resolve(false))
 
-    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit))
+    const { result } = renderHook(() => useExecutionStatus(mockFn, true, EMPTY_DATA, mockGasLimit, '10', '2'))
 
     await waitFor(() => {
       expect(mockFn).toHaveBeenCalledTimes(1)

--- a/src/logic/hooks/useEstimateTransactionGas.tsx
+++ b/src/logic/hooks/useEstimateTransactionGas.tsx
@@ -12,6 +12,8 @@ import {
   DEFAULT_MAX_PRIO_FEE,
 } from 'src/logic/wallets/ethTransactions'
 
+export const DEFAULT_GAS = '0'
+
 export enum EstimationStatus {
   LOADING = 'LOADING',
   FAILURE = 'FAILURE',
@@ -55,10 +57,10 @@ export const useEstimateTransactionGas = ({
   txData,
 }: UseEstimateTransactionGasProps): TransactionGasEstimationResult => {
   const [gasEstimation, setGasEstimation] = useState<TransactionGasEstimationResult>({
-    gasPrice: '0',
-    gasPriceFormatted: '0',
-    gasMaxPrioFee: '0',
-    gasMaxPrioFeeFormatted: '0',
+    gasPrice: DEFAULT_GAS,
+    gasPriceFormatted: DEFAULT_GAS,
+    gasMaxPrioFee: DEFAULT_GAS,
+    gasMaxPrioFeeFormatted: DEFAULT_GAS,
   })
 
   useEffect(() => {

--- a/src/logic/hooks/useExecutionStatus.ts
+++ b/src/logic/hooks/useExecutionStatus.ts
@@ -24,8 +24,9 @@ export const useExecutionStatus = ({
 
   const [status, error, loading] = useAsync(async () => {
     if (!isExecution || !txData) return EstimationStatus.SUCCESS
-    if (!gasLimit || gasLimit === DEFAULT_GAS_LIMIT || gasPrice === DEFAULT_GAS || gasMaxPrioFee === DEFAULT_GAS)
-      return EstimationStatus.LOADING
+    const isEstimationPending =
+      !gasLimit || gasLimit === DEFAULT_GAS_LIMIT || gasPrice === DEFAULT_GAS || gasMaxPrioFee === DEFAULT_GAS
+    if (isEstimationPending) return EstimationStatus.LOADING
 
     const success = await checkTxExecution()
     return success ? EstimationStatus.SUCCESS : EstimationStatus.FAILURE

--- a/src/logic/hooks/useExecutionStatus.ts
+++ b/src/logic/hooks/useExecutionStatus.ts
@@ -3,14 +3,23 @@ import { useEffect, useState } from 'react'
 import useAsync from 'src/logic/hooks/useAsync'
 import { DEFAULT_GAS_LIMIT } from 'src/logic/hooks/useEstimateGasLimit'
 
-export const useExecutionStatus = (
-  checkTxExecution: () => Promise<boolean>,
-  isExecution: boolean,
-  txData: string,
-  gasLimit: string | undefined,
-  gasPrice: string,
-  gasMaxPrioFee: string,
-): EstimationStatus => {
+type Props = {
+  checkTxExecution: () => Promise<boolean>
+  isExecution: boolean
+  txData: string
+  gasLimit: string | undefined
+  gasPrice: string
+  gasMaxPrioFee: string
+}
+
+export const useExecutionStatus = ({
+  checkTxExecution,
+  isExecution,
+  txData,
+  gasLimit,
+  gasPrice,
+  gasMaxPrioFee,
+}: Props): EstimationStatus => {
   const [executionStatus, setExecutionState] = useState<EstimationStatus>(EstimationStatus.LOADING)
 
   const [status, error, loading] = useAsync(async () => {

--- a/src/logic/hooks/useExecutionStatus.ts
+++ b/src/logic/hooks/useExecutionStatus.ts
@@ -1,22 +1,26 @@
-import { EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
+import { DEFAULT_GAS, EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
 import { useEffect, useState } from 'react'
 import useAsync from 'src/logic/hooks/useAsync'
+import { DEFAULT_GAS_LIMIT } from 'src/logic/hooks/useEstimateGasLimit'
 
 export const useExecutionStatus = (
   checkTxExecution: () => Promise<boolean>,
   isExecution: boolean,
   txData: string,
   gasLimit: string | undefined,
+  gasPrice: string,
+  gasMaxPrioFee: string,
 ): EstimationStatus => {
   const [executionStatus, setExecutionState] = useState<EstimationStatus>(EstimationStatus.LOADING)
 
   const [status, error, loading] = useAsync(async () => {
     if (!isExecution || !txData) return EstimationStatus.SUCCESS
-    if (!gasLimit) return EstimationStatus.LOADING
+    if (!gasLimit || gasLimit === DEFAULT_GAS_LIMIT || gasPrice === DEFAULT_GAS || gasMaxPrioFee === DEFAULT_GAS)
+      return EstimationStatus.LOADING
 
     const success = await checkTxExecution()
     return success ? EstimationStatus.SUCCESS : EstimationStatus.FAILURE
-  }, [checkTxExecution, isExecution, txData])
+  }, [checkTxExecution, isExecution, txData, gasPrice, gasMaxPrioFee])
 
   useEffect(() => {
     if (loading) return

--- a/src/routes/safe/components/Transactions/helpers/SpendingLimitModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/SpendingLimitModalWrapper/index.tsx
@@ -96,14 +96,21 @@ export const SpendingLimitModalWrapper = ({
     return checkAllowanceTransferExecution(allowanceTransferParams)
   }, [allowanceTransferParams])
 
-  const txEstimationExecutionStatus = useExecutionStatus(checkAllowanceTransferTx, true, '', gasLimit)
-
   const { gasPriceFormatted, gasPrice, gasMaxPrioFee, gasMaxPrioFeeFormatted } = useEstimateTransactionGas({
     manualGasPrice,
     manualMaxPrioFee,
     isExecution: true,
     txData: EMPTY_DATA,
   })
+
+  const txEstimationExecutionStatus = useExecutionStatus(
+    checkAllowanceTransferTx,
+    true,
+    '',
+    gasLimit,
+    gasPrice,
+    gasMaxPrioFee,
+  )
 
   const getGasCostFormatted = useCallback(() => {
     if (!gasLimit || gasLimit === DEFAULT_GAS_LIMIT) return '> 0.001'

--- a/src/routes/safe/components/Transactions/helpers/SpendingLimitModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/SpendingLimitModalWrapper/index.tsx
@@ -103,14 +103,14 @@ export const SpendingLimitModalWrapper = ({
     txData: EMPTY_DATA,
   })
 
-  const txEstimationExecutionStatus = useExecutionStatus(
-    checkAllowanceTransferTx,
-    true,
-    '',
+  const txEstimationExecutionStatus = useExecutionStatus({
+    checkTxExecution: checkAllowanceTransferTx,
+    isExecution: true,
+    txData: '',
     gasLimit,
     gasPrice,
     gasMaxPrioFee,
-  )
+  })
 
   const getGasCostFormatted = useCallback(() => {
     if (!gasLimit || gasLimit === DEFAULT_GAS_LIMIT) return '> 0.001'

--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -182,14 +182,14 @@ export const TxModalWrapper = ({
     return calculateTotalGasCost(gasLimit, gasPrice, gasMaxPrioFee, nativeCurrency.decimals).gasCostFormatted
   }, [gasLimit, gasMaxPrioFee, gasPrice, nativeCurrency.decimals])
 
-  const txEstimationExecutionStatus = useExecutionStatus(
+  const txEstimationExecutionStatus = useExecutionStatus({
     checkTxExecution,
-    doExecute,
-    txParameters.txData,
+    isExecution: doExecute,
+    txData: txParameters.txData,
     gasLimit,
     gasPrice,
     gasMaxPrioFee,
-  )
+  })
 
   const [submitStatus, setSubmitStatus] = useEstimationStatus(txEstimationExecutionStatus)
 

--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -161,8 +161,6 @@ export const TxModalWrapper = ({
     return checkTransactionExecution({ ...txParameters, gasLimit })
   }, [gasLimit, txParameters])
 
-  const txEstimationExecutionStatus = useExecutionStatus(checkTxExecution, doExecute, txParameters.txData, gasLimit)
-
   const { result: safeTxGasEstimation, error: safeTxGasError } = useEstimateSafeTxGas({
     isRejectTx,
     txData,
@@ -183,6 +181,15 @@ export const TxModalWrapper = ({
     if (!gasLimit || gasLimit === DEFAULT_GAS_LIMIT) return '> 0.001'
     return calculateTotalGasCost(gasLimit, gasPrice, gasMaxPrioFee, nativeCurrency.decimals).gasCostFormatted
   }, [gasLimit, gasMaxPrioFee, gasPrice, nativeCurrency.decimals])
+
+  const txEstimationExecutionStatus = useExecutionStatus(
+    checkTxExecution,
+    doExecute,
+    txParameters.txData,
+    gasLimit,
+    gasPrice,
+    gasMaxPrioFee,
+  )
 
   const [submitStatus, setSubmitStatus] = useEstimationStatus(txEstimationExecutionStatus)
 


### PR DESCRIPTION
## What it solves
Resolves #3933 

## How this PR fixes it
Returns `EstimationStatus.LOADING` while estimation for `gasPrice` and `gasMaxPrioFee` is still pending

## How to test it
1. Open the Safe app
2. Create a transaction
3. Observe the Submit button being disabled while waiting for the gas estimation
