### PR TITLE
fix: remove provider on disconnect

### DIFF
--- a/src/components/AppLayout/Header/index.tsx
+++ b/src/components/AppLayout/Header/index.tsx
@@ -14,7 +14,7 @@ import {
   userAccountSelector,
   userEnsSelector,
 } from 'src/logic/wallets/store/selectors'
-import onboard, { loadLastUsedProvider } from 'src/logic/wallets/onboard'
+import onboard, { loadLastUsedProvider, removeLastUsedProvider } from 'src/logic/wallets/onboard'
 import { isSupportedWallet } from 'src/logic/wallets/utils/walletList'
 import { initPairing, isPairingSupported } from 'src/logic/wallets/pairing/utils'
 import { wrapInSuspense } from 'src/utils/wrapInSuspense'
@@ -52,6 +52,7 @@ const HeaderComponent = (): React.ReactElement => {
 
   const onDisconnect = () => {
     onboard().walletReset()
+    removeLastUsedProvider()
   }
 
   const getProviderInfoBased = () => {

--- a/src/logic/wallets/store/middleware/index.ts
+++ b/src/logic/wallets/store/middleware/index.ts
@@ -12,7 +12,7 @@ import { trackEvent } from 'src/utils/googleTagManager'
 import { WALLET_EVENTS } from 'src/utils/events/wallet'
 import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 import { resetWeb3, setWeb3 } from 'src/logic/wallets/getWeb3'
-import onboard, { removeLastUsedProvider, saveLastUsedProvider } from 'src/logic/wallets/onboard'
+import onboard, { saveLastUsedProvider } from 'src/logic/wallets/onboard'
 import { checksumAddress } from 'src/utils/checksumAddress'
 import { shouldSwitchNetwork } from 'src/logic/wallets/utils/network'
 
@@ -41,7 +41,6 @@ const providerMiddleware =
     // No wallet is connected via onboard, reset provider
     if (!name && !account && !network) {
       resetWeb3()
-      removeLastUsedProvider()
     }
 
     // Wallet 'partially' connected: only a subset of onboard subscription(s) have fired

--- a/src/logic/wallets/store/middleware/index.ts
+++ b/src/logic/wallets/store/middleware/index.ts
@@ -12,13 +12,11 @@ import { trackEvent } from 'src/utils/googleTagManager'
 import { WALLET_EVENTS } from 'src/utils/events/wallet'
 import { instantiateSafeContracts } from 'src/logic/contracts/safeContracts'
 import { resetWeb3, setWeb3 } from 'src/logic/wallets/getWeb3'
-import onboard, { removeLastUsedProvider, saveLastUsedProvider } from 'src/logic/wallets/onboard'
+import onboard, { saveLastUsedProvider } from 'src/logic/wallets/onboard'
 import { checksumAddress } from 'src/utils/checksumAddress'
 import { shouldSwitchNetwork } from 'src/logic/wallets/utils/network'
 
 const UNKNOWN_PEER = 'Unknown'
-
-let prevAccount = ''
 
 const providerMiddleware =
   (store: ReturnType<typeof reduxStore>) =>
@@ -39,18 +37,6 @@ const providerMiddleware =
 
     const state = store.getState()
     const { name, account, network, loaded, available } = providerSelector(state)
-
-    // Onboard provides no disconnection event, so we must manually handle
-    // removing the last used provider when the wallet disconnects itself
-    const didConnect = !prevAccount && account
-    if (didConnect) {
-      prevAccount = account
-    }
-    const didDisconnect = prevAccount && !account
-    if (didDisconnect) {
-      prevAccount = ''
-      removeLastUsedProvider()
-    }
 
     // No wallet is connected via onboard, reset provider
     if (!name && !account && !network) {


### PR DESCRIPTION
## What it solves
Resolves #3938

## How this PR fixes it
Removal of the last provider cache occurs with clicking disconnect.

It was previously removed when onboard was totally disconnected and the provider store was empty, which occurs when switching chain. We didn't experience this bug before as the removal of the wrong key was attempted.

## How to test it
Connect a wallet and:
1. switch to a supported chain and observe successful reconnection.
2. switch to an unsupported chain and observe no reconnection. Switching back to a supported chain should successfully reconnect,