### PR TITLE
fix: error calling renamed cypress command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,6 @@ REACT_APP_APP_VERSION=$npm_package_version
 # Contracts Addresses
 REACT_APP_SPENDING_LIMIT_MODULE_ADDRESS=
 
+# Test mnemonic for Cypress e2e testing
+CYPRESS_MNEMONIC=
+

--- a/cypress/integration/create_safe.spec.js
+++ b/cypress/integration/create_safe.spec.js
@@ -1,12 +1,12 @@
 describe('Create Safe', () => {
   it('should create a new safe', () => {
-    cy.configWindow({ connected: true })
+    cy.connectE2EWallet()
 
     cy.visit('/')
 
     cy.contains('a', 'Accept all').click()
     cy.get('p').contains('Rinkeby').click()
-    cy.get('[data-testid=connected-wallet]').should('contain', 'e2e-wallet')
+    cy.get('[data-testid=connected-wallet]').should('contain', 'E2E Wallet')
     cy.contains('Create new Safe').click()
     cy.contains('Continue').click()
     cy.get('[data-testid=create-safe-name-field]').type('Test Safe')

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -13,11 +13,14 @@
 // the project's config changing)
 
 import { rmdir } from 'fs'
+import { config } from 'dotenv'
+
+config()
 
 /**
  * @type {Cypress.PluginConfig}
  */
-module.exports = (on) => {
+module.exports = (on, config) => {
   on('task', {
     deleteFolder(folderName) {
       console.log('deleting folder %s', folderName)
@@ -33,4 +36,8 @@ module.exports = (on) => {
       })
     },
   })
+
+  config.env.CYPRESS_MNEMONIC = process.env.CYPRESS_MNEMONIC
+
+  return config
 }


### PR DESCRIPTION
## What it solves
1) Fix error calling renamed cypress cy.configWindow custom command
2) Add a way to load CYPRESS_MNEMONIC (Can be done in [several ways](https://docs.cypress.io/guides/guides/environment-variables#Setting))
