### PR TITLE
style fix: remove gap under tx list

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -483,7 +483,6 @@ export const StyledScrollableBar = styled.div`
 `
 
 export const ScrollableTransactionsContainer = styled(StyledScrollableBar)`
-  height: calc(100vh - 218px);
   overflow-x: hidden;
   overflow-y: auto;
   width: 100%;


### PR DESCRIPTION
A small CSS fix to remove the weird gap under the tx list.

Before:
<img width="965" alt="Screenshot 2022-06-09 at 12 17 22" src="https://user-images.githubusercontent.com/381895/172824427-2dfb9978-dbba-44b7-9ccd-b6178d32ea40.png">

After:
<img width="972" alt="Screenshot 2022-06-09 at 12 16 57" src="https://user-images.githubusercontent.com/381895/172824531-ca2a4ad0-87e9-4ef1-b1d2-6254c14634fb.png">

