### PR TITLE
Revert "fix: only use 2 decimals for fiat (#3935)"

### DIFF
--- a/src/logic/tokens/utils/__tests__/formatAmount.test.ts
+++ b/src/logic/tokens/utils/__tests__/formatAmount.test.ts
@@ -143,10 +143,10 @@ describe('formatCurrency', () => {
     // then
     expect(result).toBe(expectedResult)
   })
-  it('Given a number in format XXXXX.XXX returns a number of format XX,XXX.XX', () => {
+  it('Given a number in format XXXXX.XXX returns a number of format XX,XXX.XXX', () => {
     // given
     const input = 19797.899
-    const expectedResult = '19,797.90 EUR'
+    const expectedResult = '19,797.899 EUR'
 
     // when
     const result = formatCurrency(input.toString(), 'EUR')
@@ -154,10 +154,10 @@ describe('formatCurrency', () => {
     // then
     expect(result).toBe(expectedResult)
   })
-  it('Given a number in format XXXXXXXX.XXX returns a number of format XX,XXX,XXX.XX', () => {
+  it('Given a number in format XXXXXXXX.XXX returns a number of format XX,XXX,XXX.XXX', () => {
     // given
     const input = 19797899.479
-    const expectedResult = '19,797,899.48 EUR'
+    const expectedResult = '19,797,899.479 EUR'
 
     // when
     const result = formatCurrency(input.toString(), 'EUR')
@@ -165,10 +165,10 @@ describe('formatCurrency', () => {
     // then
     expect(result).toBe(expectedResult)
   })
-  it('Given a number in format XXXXXXXXXXX.XXX returns a number of format XX,XXX,XXX,XXX.XX', () => {
+  it('Given a number in format XXXXXXXXXXX.XXX returns a number of format XX,XXX,XXX,XXX.XXX', () => {
     // given
     const input = 19797899479.999
-    const expectedResult = '19,797,899,480.00 EUR'
+    const expectedResult = '19,797,899,479.999 EUR'
 
     // when
     const result = formatCurrency(input.toString(), 'EUR')

--- a/src/logic/tokens/utils/formatAmount.ts
+++ b/src/logic/tokens/utils/formatAmount.ts
@@ -44,10 +44,9 @@ export const formatAmount = (number: string): string => {
   return numberFloat
 }
 
-// Note: we can't use Intl.NumberFormat's 'currency' style as it doesn't support all fiats
 const currencyFormatter = new Intl.NumberFormat(LOCALE, {
   minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
+  maximumFractionDigits: 8,
 })
 
 export const formatCurrency = (amount: string, currencySelected: string): string => {

--- a/src/routes/safe/components/Balances/dataFetcher.ts
+++ b/src/routes/safe/components/Balances/dataFetcher.ts
@@ -1,5 +1,5 @@
 import { List } from 'immutable'
-import { formatAmount, formatCurrency } from 'src/logic/tokens/utils/formatAmount'
+import { formatCurrency } from 'src/logic/tokens/utils/formatAmount'
 import { TableColumn } from 'src/components/Table/types.d'
 import { Token } from 'src/logic/tokens/store/model/token'
 export const BALANCE_TABLE_ASSET_ID = 'asset'
@@ -26,7 +26,7 @@ export const getBalanceData = (safeTokens: List<Token>, currencySelected: string
         symbol: token.symbol,
       },
       assetOrder: token.name,
-      [BALANCE_TABLE_BALANCE_ID]: `${formatAmount(tokenBalance?.toString() || '0')} ${token.symbol}`,
+      [BALANCE_TABLE_BALANCE_ID]: formatCurrency(tokenBalance?.toString() || '0', token.symbol),
       balanceOrder: Number(tokenBalance),
       [BALANCE_TABLE_VALUE_ID]: formatCurrency(fiatBalance?.toString() || '0', currencySelected),
       valueOrder: Number(tokenBalance),


### PR DESCRIPTION
This reverts commit 1d040c1369f3f7fb7a78a333c02aeb83af7b08d2.

## What it solves
Resolves token decimals.

## How this PR fixes it
Reverts change of currency formatting.

## How to test it
Open assets list and observe the currency and tokens as before.