### PR TITLE
fix: prevent endless estimation on erronous gas limit estimation

### DIFF
--- a/src/logic/hooks/__tests__/useExecutionStatus.test.ts
+++ b/src/logic/hooks/__tests__/useExecutionStatus.test.ts
@@ -43,7 +43,7 @@ describe('useExecutionStatus', () => {
     })
   })
 
-  it('returns LOADING if gasLimit is 0', async () => {
+  it('returns SUCCESS if gasLimit is 0', async () => {
     const mockFn = jest.fn(() => Promise.resolve(true))
 
     const { result } = renderHook(() =>
@@ -58,8 +58,8 @@ describe('useExecutionStatus', () => {
     )
 
     await waitFor(() => {
-      expect(result.current).toBe(EstimationStatus.LOADING)
-      expect(mockFn).toHaveBeenCalledTimes(0)
+      expect(result.current).toBe(EstimationStatus.SUCCESS)
+      expect(mockFn).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/logic/hooks/useExecutionStatus.ts
+++ b/src/logic/hooks/useExecutionStatus.ts
@@ -1,7 +1,6 @@
 import { DEFAULT_GAS, EstimationStatus } from 'src/logic/hooks/useEstimateTransactionGas'
 import { useEffect, useState } from 'react'
 import useAsync from 'src/logic/hooks/useAsync'
-import { DEFAULT_GAS_LIMIT } from 'src/logic/hooks/useEstimateGasLimit'
 
 type Props = {
   checkTxExecution: () => Promise<boolean>
@@ -24,8 +23,7 @@ export const useExecutionStatus = ({
 
   const [status, error, loading] = useAsync(async () => {
     if (!isExecution || !txData) return EstimationStatus.SUCCESS
-    const isEstimationPending =
-      !gasLimit || gasLimit === DEFAULT_GAS_LIMIT || gasPrice === DEFAULT_GAS || gasMaxPrioFee === DEFAULT_GAS
+    const isEstimationPending = !gasLimit || gasPrice === DEFAULT_GAS || gasMaxPrioFee === DEFAULT_GAS
     if (isEstimationPending) return EstimationStatus.LOADING
 
     const success = await checkTxExecution()


### PR DESCRIPTION
## What it solves
Resolves #3958

## How this PR fixes it
Errors during gas estimation (GS13) will cause a fallback of gas limit 0.
The hook `useExecutionStatus` now accepts a gas limit of 0 as not a loading state.

## How to test it
See #3958 

## Analytics changes

## Screenshots
