### PR TITLE
test: pass execution environment to Cypress

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,6 +171,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: cypress-io/github-action@v2
         with:
+          env:
+            CYPRESS_ENV: ${{ env.REACT_APP_ENV}}
           spec: cypress/integration/smoke/*.spec.js
           browser: chrome
           record: false

--- a/cypress/integration/smoke/dashboard.spec.js
+++ b/cypress/integration/smoke/dashboard.spec.js
@@ -1,6 +1,9 @@
 const SAFE = 'rin:0xB5ef359e8eBDAd1cd7695FFEF3f6F6D7d5e79B08'
 
 describe('Dashboard', () => {
+  const safeAppsUrl =
+    Cypress.env('CYPRESS_ENV') === 'prod' ? 'https://apps.gnosis-safe.io' : 'https://safe-apps.dev.gnosisdev.com'
+
   before(() => {
     // Go to the test Safe home page
     cy.visit(`/${SAFE}/home`)
@@ -9,7 +12,7 @@ describe('Dashboard', () => {
 
   it('should display the dashboard title', () => {
     cy.contains('main h1', 'Dashboard')
-  }) 
+  })
 
   it('should display the overview widget', () => {
     cy.contains('main p', SAFE).should('exist')
@@ -20,9 +23,10 @@ describe('Dashboard', () => {
   })
 
   it('should display the mobile banner', () => {
-    const appStoreLink = 'https://apps.apple.com/app/apple-store/id1515759131?pt=119497694&ct=Web%20App%20Dashboard&mt=8'
+    const appStoreLink =
+      'https://apps.apple.com/app/apple-store/id1515759131?pt=119497694&ct=Web%20App%20Dashboard&mt=8'
     cy.get(`a[href="${appStoreLink}"]`).should('exist')
-    
+
     cy.get('button[aria-label="Close mobile banner"]').click()
     cy.contains('button', 'Already use it!')
     cy.contains('button', 'Not interested').click()
@@ -34,16 +38,10 @@ describe('Dashboard', () => {
     cy.contains('main', 'This Safe has no queued transactions').should('not.exist')
 
     // Queued txns
-    cy.contains(
-      `main a[href="/app/${SAFE}/transactions/queue"]`,
-      '0' + 'addOwnerWithThreshold' + '1/1'
-    ).should('exist')
+    cy.contains(`main a[href="/app/${SAFE}/transactions/queue"]`, '0' + 'addOwnerWithThreshold' + '1/1').should('exist')
 
-    cy.contains(
-      `main a[href="/app/${SAFE}/transactions/queue"]`,
-      '2' + 'Send' + '-0.001 USDC' + '1/1'
-    ).should('exist')
-  
+    cy.contains(`main a[href="/app/${SAFE}/transactions/queue"]`, '2' + 'Send' + '-0.001 USDC' + '1/1').should('exist')
+
     cy.contains(`a[href="/app/${SAFE}/transactions/queue"]`, 'View All')
   })
 
@@ -52,13 +50,11 @@ describe('Dashboard', () => {
 
     // Tx Builder app
     cy.contains('main p', 'Use Transaction Builder')
-    cy.get(`a[href="/app/${SAFE}/apps?appUrl=https://safe-apps.dev.gnosisdev.com/tx-builder"]`)
-      .should('exist')
+    cy.get(`a[href="/app/${SAFE}/apps?appUrl=${safeAppsUrl}/tx-builder"]`).should('exist')
 
     // WalletConnect app
     cy.contains('main p', 'Use WalletConnect')
-    cy.get(`a[href="/app/${SAFE}/apps?appUrl=https://safe-apps.dev.gnosisdev.com/wallet-connect"]`)
-      .should('exist')
+    cy.get(`a[href="/app/${SAFE}/apps?appUrl=${safeAppsUrl}/wallet-connect"]`).should('exist')
 
     // Featured apps have a Safe-specific link
     cy.get(`main a[href^="/app/${SAFE}/apps?appUrl=http"]`).should('have.length', 2)

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -8,6 +8,7 @@ const DEPLOYMENTS = {
 }
 
 const command = `cypress ${process.argv[2]}`
-const env = process.argv?.[3]
+// To accept 'prod' or 'production' as an argument
+let env = process.argv?.[3] === 'production' ? 'prod' : process.argv?.[3]
 
-exec(env ? `${command} --config baseUrl=${DEPLOYMENTS[env]}` : command)
+exec(env ? `${command} --config baseUrl=${DEPLOYMENTS[env]} --env CYPRESS_ENV=${env}` : command)


### PR DESCRIPTION
## What it solves
Fixes failing E2E CI tests in `release/3.26.0`

## How this PR fixes it
The execution environment is passed to the cypress runner to switch between _DEV_ and _PROD_ `safeAppsUrl`

## How to test it
The `e2e` job in the `deploy` workflow runs all tests successfully
