### PR TITLE
fix: Track more safe creation steps

### DIFF
--- a/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
+++ b/src/routes/CreateSafePage/components/SafeCreationProcess.tsx
@@ -131,6 +131,7 @@ const createNewSafe = (userAddress: string, onHash: (hash: string) => void): Pro
     deploymentTx
       .send(sendParams)
       .once('transactionHash', (txHash) => {
+        trackEvent(CREATE_SAFE_EVENTS.SUBMIT_CREATE_SAFE)
         onHash(txHash)
 
         saveToStorage(SAFE_PENDING_CREATION_STORAGE_KEY, {
@@ -255,6 +256,7 @@ function SafeCreationProcess(): ReactElement {
   }
 
   const onRetry = (): void => {
+    trackEvent(CREATE_SAFE_EVENTS.RETRY_CREATE_SAFE)
     const safeCreationFormValues = loadSavedDataOrLeave()
 
     if (!safeCreationFormValues) {
@@ -272,6 +274,7 @@ function SafeCreationProcess(): ReactElement {
   }
 
   const onCancel = () => {
+    trackEvent(CREATE_SAFE_EVENTS.CANCEL_CREATE_SAFE)
     removeFromStorage(SAFE_PENDING_CREATION_STORAGE_KEY)
     goToWelcomePage()
   }

--- a/src/routes/opening/index.tsx
+++ b/src/routes/opening/index.tsx
@@ -6,7 +6,6 @@ import styled from 'styled-components'
 import { ErrorFooter } from 'src/routes/opening/components/Footer'
 import { isConfirmationStep, steps } from './steps'
 
-import Button from 'src/components/layout/Button'
 import Heading from 'src/components/layout/Heading'
 import Img from 'src/components/layout/Img'
 import Paragraph from 'src/components/layout/Paragraph'
@@ -315,12 +314,6 @@ export const SafeDeployment = ({
           ) : null}
         </BodyFooter>
       </Body>
-
-      {stepIndex !== 0 && (
-        <BackButton color="primary" minWidth={140} onClick={onCancel} data-testid="safe-creation-back-btn">
-          Back
-        </BackButton>
-      )}
     </Wrapper>
   )
 }
@@ -423,9 +416,4 @@ const BodyFooter = styled.div`
   display: flex;
   justify-content: center;
   align-items: flex-end;
-`
-
-const BackButton = styled(Button)`
-  grid-column: 2;
-  margin: 20px auto 0;
 `

--- a/src/routes/opening/index.tsx
+++ b/src/routes/opening/index.tsx
@@ -25,6 +25,8 @@ import { showNotification } from 'src/logic/notifications/store/notifications'
 import { getNewSafeAddressFromLogs } from 'src/routes/opening/utils/getSafeAddressFromLogs'
 import { getExplorerInfo } from 'src/config'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
+import { trackEvent } from 'src/utils/googleTagManager'
+import { CREATE_SAFE_EVENTS } from 'src/utils/events/createLoadSafe'
 
 export const SafeDeployment = ({
   creationTxHash,
@@ -119,6 +121,7 @@ export const SafeDeployment = ({
         setStepIndex(1)
         setIntervalStarted(true)
       } catch (err) {
+        trackEvent(CREATE_SAFE_EVENTS.REJECT_CREATE_SAFE)
         onError(err)
       }
     }

--- a/src/routes/opening/index.tsx
+++ b/src/routes/opening/index.tsx
@@ -27,6 +27,7 @@ import { getExplorerInfo } from 'src/config'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { trackEvent } from 'src/utils/googleTagManager'
 import { CREATE_SAFE_EVENTS } from 'src/utils/events/createLoadSafe'
+import { isWalletRejection } from 'src/logic/wallets/errors'
 
 export const SafeDeployment = ({
   creationTxHash,
@@ -121,7 +122,9 @@ export const SafeDeployment = ({
         setStepIndex(1)
         setIntervalStarted(true)
       } catch (err) {
-        trackEvent(CREATE_SAFE_EVENTS.REJECT_CREATE_SAFE)
+        if (isWalletRejection(err)) {
+          trackEvent(CREATE_SAFE_EVENTS.REJECT_CREATE_SAFE)
+        }
         onError(err)
       }
     }

--- a/src/utils/events/createLoadSafe.ts
+++ b/src/utils/events/createLoadSafe.ts
@@ -20,6 +20,22 @@ const CREATE_SAFE = {
     event: GTM_EVENT.META,
     action: 'Threshold',
   },
+  SUBMIT_CREATE_SAFE: {
+    event: GTM_EVENT.META,
+    action: 'Submit Create Safe',
+  },
+  REJECT_CREATE_SAFE: {
+    event: GTM_EVENT.META,
+    action: 'Reject Create Safe',
+  },
+  RETRY_CREATE_SAFE: {
+    event: GTM_EVENT.META,
+    action: 'Retry Create Safe',
+  },
+  CANCEL_CREATE_SAFE: {
+    event: GTM_EVENT.META,
+    action: 'Cancel Create Safe',
+  },
   CREATED_SAFE: {
     event: GTM_EVENT.META,
     action: 'Created Safe',

--- a/src/utils/events/createLoadSafe.ts
+++ b/src/utils/events/createLoadSafe.ts
@@ -22,19 +22,19 @@ const CREATE_SAFE = {
   },
   SUBMIT_CREATE_SAFE: {
     event: GTM_EVENT.META,
-    action: 'Submit Create Safe',
+    action: 'Submit Safe creation',
   },
   REJECT_CREATE_SAFE: {
     event: GTM_EVENT.META,
-    action: 'Reject Create Safe',
+    action: 'Reject Safe creation',
   },
   RETRY_CREATE_SAFE: {
     event: GTM_EVENT.META,
-    action: 'Retry Create Safe',
+    action: 'Retry Safe creation',
   },
   CANCEL_CREATE_SAFE: {
     event: GTM_EVENT.META,
-    action: 'Cancel Create Safe',
+    action: 'Cancel Safe creation',
   },
   CREATED_SAFE: {
     event: GTM_EVENT.META,


### PR DESCRIPTION
## What it solves
Part of #3948 

## How this PR fixes it

Adds additional tracking for Safe Creation:

- Tx was submitted by user
- Tx was rejected by user
- Safe Creation was canceled
- Safe Created was retried

Removes the "Back" Button that is displayed after the tx is submitted.

## How to test it

1. Open the Safe app
2. Create a new Safe
3. Observe GTM Events being sent when rejecting/submitting the Tx in the wallet provider
4. Observe GTM Events being sent when clicking Retry or Cancel
5. Observe no Back Button in the Footer after Tx Submission
