### PR TITLE
fix: Safe Apps test

### DIFF
--- a/src/routes/safe/components/Apps/components/AppsList.test.tsx
+++ b/src/routes/safe/components/Apps/components/AppsList.test.tsx
@@ -303,7 +303,7 @@ describe('Safe Apps -> AppsList -> Share Safe Apps', () => {
     })
   })
 
-  it.only('Copies the Safe app URL to the clipboard and shows a snackbar', async () => {
+  it('Copies the Safe app URL to the clipboard and shows a snackbar', async () => {
     const copyToClipboardSpy = jest.spyOn(clipboard, 'copyToClipboard')
 
     copyToClipboardSpy.mockImplementation(() => jest.fn())


### PR DESCRIPTION
## What it solves
Resolves only one test running in the `AppsList` test

## How this PR fixes it
`only` has been removed from a test.

## How to test it
Run the `AppsList` test and observe it passing.