### PR TITLE
feat: add `timestamp`, `read` and `action` to notifications

### DIFF
--- a/src/logic/hooks/useNotifier.tsx
+++ b/src/logic/hooks/useNotifier.tsx
@@ -19,24 +19,38 @@ const useNotifier = (): void => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const key = notification.options!.key!
 
+      // Dismiss notification via Notistack
       if (notification.dismissed) {
         closeSnackbar(key)
         continue
       }
 
+      // Do nothing if notification is already on screen
       if (onScreenKeys.includes(key)) {
         continue
       }
 
+      // `onExited` runs after a notification unmounts meaning that already
+      // closed notifications would 'close' again, marking them as unread
+      let wasClosed = false
+
+      // Display notification with Notistack
       enqueueSnackbar(notification.message, {
         ...notification.options,
         onExited: () => {
           // Cleanup store/cache when notification has unmounted
-          dispatch(closeNotification({ key }))
+          if (!wasClosed) {
+            dispatch(closeNotification({ key, read: false }))
+          }
           onScreenKeys = onScreenKeys.filter((onScreenKey) => onScreenKey !== key)
         },
         action: (
-          <IconButton onClick={() => dispatch(closeNotification({ key }))}>
+          <IconButton
+            onClick={() => {
+              dispatch(closeNotification({ key }))
+              wasClosed = true
+            }}
+          >
             <CloseIcon />
           </IconButton>
         ),

--- a/src/logic/notifications/notificationTypes.ts
+++ b/src/logic/notifications/notificationTypes.ts
@@ -13,7 +13,7 @@ const longDuration = 10000
 export type Notification = {
   message: SnackbarMessage
   options?: OptionsObject
-  dismissed?: boolean
+  action?: unknown // Will specify the type when actions are added
 }
 
 enum NOTIFICATION_IDS {


### PR DESCRIPTION
## What it solves
Adds extra 'state' flags for notifications

## How this PR fixes it
`timestamp` (for showing the date in the notification centre), `read` (whether the notification is (un-)read) and `action` (likely a `ReactElement` link) have been added to the notification system.

## How to test it
Dispatch a notification and observe the `timestamp`/`read` flags in the store by default. `read` will be set to `true` unless the notification is not manually dismissed.

`action` is not used yet and will not be present in the store.