### PR TITLE
feat: notification header bell

### DIFF
--- a/src/components/AppLayout/Header/components/Layout.tsx
+++ b/src/components/AppLayout/Header/components/Layout.tsx
@@ -20,6 +20,7 @@ import { shouldSwitchWalletChain } from 'src/logic/wallets/store/selectors'
 import { useSelector } from 'react-redux'
 import { OVERVIEW_EVENTS } from 'src/utils/events/overview'
 import Track from 'src/components/Track'
+import Notifications from 'src/components/AppLayout/Header/components/Notifications'
 
 const styles = () => ({
   root: {
@@ -90,7 +91,8 @@ const WalletPopup = ({ anchorEl, providerDetails, classes, open, onClose }) => {
 }
 
 const Layout = ({ classes, providerDetails, providerInfo }) => {
-  const { clickAway, open, toggle } = useStateHandler()
+  const { clickAway: clickAwayNotifications, open: openNotifications, toggle: toggleNotifications } = useStateHandler()
+  const { clickAway: clickAwayWallet, open: openWallet, toggle: toggleWallet } = useStateHandler()
   const { clickAway: clickAwayNetworks, open: openNetworks, toggle: toggleNetworks } = useStateHandler()
   const isWrongChain = useSelector(shouldSwitchWalletChain)
 
@@ -114,24 +116,27 @@ const Layout = ({ classes, providerDetails, providerInfo }) => {
       )}
 
       <Divider />
+      <Notifications open={openNotifications} toggle={toggleNotifications} clickAway={clickAwayNotifications} />
+
+      <Divider />
       <Provider
         info={providerInfo}
-        open={open}
-        toggle={toggle}
+        open={openWallet}
+        toggle={toggleWallet}
         render={(providerRef) =>
           providerRef.current && (
             <WalletPopup
               anchorEl={providerRef.current}
               providerDetails={providerDetails}
-              open={open}
+              open={openWallet}
               classes={classes}
-              onClose={clickAway}
+              onClose={clickAwayWallet}
             />
           )
         }
       />
-      <Divider />
 
+      <Divider />
       <NetworkSelector open={openNetworks} toggle={toggleNetworks} clickAway={clickAwayNetworks} />
     </Row>
   )

--- a/src/components/AppLayout/Header/components/Notifications.tsx
+++ b/src/components/AppLayout/Header/components/Notifications.tsx
@@ -31,7 +31,6 @@ const Notifications = ({}: Props): ReactElement => {
       <IconButton>
         <StyledBadge
           variant="dot"
-          color="primary"
           invisible={!hasUnread}
           anchorOrigin={{
             vertical: 'bottom',

--- a/src/components/AppLayout/Header/components/Notifications.tsx
+++ b/src/components/AppLayout/Header/components/Notifications.tsx
@@ -1,0 +1,48 @@
+import { ReactElement, useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import { IconButton, Badge } from '@material-ui/core'
+import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone'
+import styled from 'styled-components'
+
+import { ReturnValue as Props } from 'src/logic/hooks/useStateHandler'
+import { selectNotifications } from 'src/logic/notifications/store/notifications'
+import { primary400 } from 'src/theme/variables'
+
+const Wrapper = styled.div`
+  width: 44px;
+  display: flex;
+  justify-content: center;
+`
+
+const StyledBadge = styled(Badge)`
+  .MuiBadge-badge {
+    background-color: ${primary400};
+  }
+`
+
+// Props will be used in popper
+const Notifications = ({}: Props): ReactElement => {
+  const notifications = useSelector(selectNotifications)
+
+  const hasUnread = useMemo(() => notifications.some(({ read }) => !read), [notifications])
+
+  return (
+    <Wrapper>
+      <IconButton>
+        <StyledBadge
+          variant="dot"
+          color="primary"
+          invisible={!hasUnread}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right',
+          }}
+        >
+          <NotificationsNoneIcon />
+        </StyledBadge>
+      </IconButton>
+    </Wrapper>
+  )
+}
+
+export default Notifications


### PR DESCRIPTION
## What it solves
Adds bell to header with unread badge.

## How this PR fixes it
A new bell icon button has been added to the header, displaying a dot badge when there are unread notifications in the store.

## How to test it
Observe the new bell in the header. When attempting to sign a transaction, a notification is dispatched and there will be a green badge on the bell.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/173547888-dcb33ced-6eb7-4b2d-95c1-4d9a265faecd.png)