### PR TITLE
Fix: gas estimation in 1.1.1 Safes

### DIFF
--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -100,7 +100,7 @@ export const TxModalWrapper = ({
   isSubmitDisabled,
   isRejectTx = false,
 }: Props): React.ReactElement => {
-  const [manualSafeTxGas, setManualSafeTxGas] = useState<string>('0')
+  const [manualSafeTxGas, setManualSafeTxGas] = useState<string>('')
   const [manualGasPrice, setManualGasPrice] = useState<string>()
   const [manualMaxPrioFee, setManualMaxPrioFee] = useState<string>()
   const [manualGasLimit, setManualGasLimit] = useState<string>()
@@ -120,6 +120,15 @@ export const TxModalWrapper = ({
   const isOffChainSignature = checkIfOffChainSignatureIsPossible(doExecute, isSmartContract, safeVersion)
   const approvalAndExecution = isApproveAndExecute(Number(threshold), confirmationsLen, preApprovingOwner)
 
+  const { result: safeTxGasEstimation, error: safeTxGasError } = useEstimateSafeTxGas({
+    isRejectTx,
+    txData,
+    txRecipient: txTo || safeAddress,
+    txAmount: txValue,
+    operation,
+  })
+  if (safeTxGas == null) safeTxGas = safeTxGasEstimation
+
   const txParameters = useMemo(
     () => ({
       safeAddress,
@@ -133,7 +142,7 @@ export const TxModalWrapper = ({
       gasPrice: '0',
       gasToken: ZERO_ADDRESS,
       refundReceiver: ZERO_ADDRESS,
-      safeTxGas: safeTxGas || manualSafeTxGas || '0',
+      safeTxGas: manualSafeTxGas || safeTxGas || '0',
       approvalAndExecution,
     }),
     [
@@ -160,15 +169,6 @@ export const TxModalWrapper = ({
   const checkTxExecution = useCallback((): Promise<boolean> => {
     return checkTransactionExecution({ ...txParameters, gasLimit })
   }, [gasLimit, txParameters])
-
-  const { result: safeTxGasEstimation, error: safeTxGasError } = useEstimateSafeTxGas({
-    isRejectTx,
-    txData,
-    txRecipient: txTo || safeAddress,
-    txAmount: txValue,
-    operation,
-  })
-  if (safeTxGas == null) safeTxGas = safeTxGasEstimation
 
   const { gasPriceFormatted, gasPrice, gasMaxPrioFee, gasMaxPrioFeeFormatted } = useEstimateTransactionGas({
     manualGasPrice,

--- a/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
+++ b/src/routes/safe/components/Transactions/helpers/TxModalWrapper/index.tsx
@@ -100,7 +100,7 @@ export const TxModalWrapper = ({
   isSubmitDisabled,
   isRejectTx = false,
 }: Props): React.ReactElement => {
-  const [manualSafeTxGas, setManualSafeTxGas] = useState<string>('')
+  const [manualSafeTxGas, setManualSafeTxGas] = useState<string>()
   const [manualGasPrice, setManualGasPrice] = useState<string>()
   const [manualMaxPrioFee, setManualMaxPrioFee] = useState<string>()
   const [manualGasLimit, setManualGasLimit] = useState<string>()


### PR DESCRIPTION
## What it solves
Resolves #3983 

## How this PR fixes it
Gas estimation in 1.1.1 Safes was broken in many ways since #3868 or possibly even before.

The variable `safeTxGas` was redefined after its first usage. I moved it up.

## How to test it
* Open a 1/X Safe v.1.1.1
* Make a simple tx
* Check that the gas limit and total gas depend on the safeTxGas

NB: editing the safeTxGas in the Advanced form **will not** automatically update the gas limit. This hasn't changed from prod.

Before (gas limit 60k):
<img width="509" alt="Screenshot 2022-06-20 at 18 38 33" src="https://user-images.githubusercontent.com/381895/174646578-7b07e2d1-af96-4916-8d31-d6a84faabd70.png">

After (gas limit 100k):
<img width="513" alt="Screenshot 2022-06-20 at 18 38 17" src="https://user-images.githubusercontent.com/381895/174646614-a15dfbc7-1f6c-4c8a-90a0-6bf4838c00e4.png">

