### PR TITLE
Fix: history polling always 1st page

### DIFF
--- a/src/logic/safe/store/actions/transactions/fetchTransactions/index.ts
+++ b/src/logic/safe/store/actions/transactions/fetchTransactions/index.ts
@@ -5,18 +5,14 @@ import {
   addHistoryTransactions,
   addQueuedTransactions,
 } from 'src/logic/safe/store/actions/transactions/gatewayTransactions'
-import { loadHistoryTransactions, loadQueuedTransactions } from './loadGatewayTransactions'
+import { loadHistoryTip, loadQueuedTransactions } from './loadGatewayTransactions'
 import { AppReduxState } from 'src/store'
-import { history } from 'src/routes/routes'
-import { isTxFilter } from 'src/routes/safe/components/Transactions/TxList/Filter/utils'
 
 export default (chainId: string, safeAddress: string) =>
   async (dispatch: ThunkDispatch<AppReduxState, undefined, AnyAction>): Promise<void> => {
     const loadHistory = async () => {
       try {
-        const query = Object.fromEntries(new URLSearchParams(history.location.search))
-        const filter = isTxFilter(query) ? query : undefined
-        const values = await loadHistoryTransactions(safeAddress, filter)
+        const values = await loadHistoryTip(safeAddress)
         dispatch(addHistoryTransactions({ chainId, safeAddress, values }))
       } catch (e) {
         e.log()

--- a/src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions.ts
+++ b/src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions.ts
@@ -144,6 +144,24 @@ export const loadHistoryTransactions = async (
   }
 }
 
+export const loadHistoryTip = async (safeAddress: string): Promise<HistoryGatewayResponse['results']> => {
+  const chainId = _getChainId()
+
+  try {
+    const { results, next, previous } = await getTransactionHistory(chainId, safeAddress)
+
+    // If it's the very first request to fetch the history for this Safe
+    if (!historyPointers[chainId]?.[safeAddress]) {
+      historyPointers[chainId] = historyPointers[chainId] || {}
+      historyPointers[chainId][safeAddress] = { next, previous }
+    }
+
+    return results
+  } catch (e) {
+    throw new CodedException(Errors._602, e.message)
+  }
+}
+
 /************/
 /*  QUEUED  */
 /************/


### PR DESCRIPTION
After #3766, tx history was polled with the wrong query params. This fix makes sure the poller always fetches the tip of the history.