### PR TITLE
fix: history polling `next`/transactions remaining pending

### DIFF
--- a/src/logic/safe/store/actions/transactions/__tests__/loadGatewayTransactions.test.ts
+++ b/src/logic/safe/store/actions/transactions/__tests__/loadGatewayTransactions.test.ts
@@ -1,0 +1,79 @@
+import * as gatewaySDK from '@gnosis.pm/safe-react-gateway-sdk'
+import { FilterType } from 'src/routes/safe/components/Transactions/TxList/Filter'
+import { _getHistoryPageUrl, _getTxHistory } from '../fetchTransactions/loadGatewayTransactions'
+
+jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => {
+  const original = jest.requireActual('@gnosis.pm/safe-react-gateway-sdk')
+  return {
+    ...original,
+    getIncomingTransfers: jest.fn,
+    getMultisigTransactions: jest.fn,
+    getModuleTransactions: jest.fn,
+    getTransactionHistory: jest.fn,
+  }
+})
+
+describe('loadGatewayTransactions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('getTxHistory', () => {
+    it('fetches incoming transfers according to type', async () => {
+      const spy = jest.spyOn(gatewaySDK, 'getIncomingTransfers')
+
+      await _getTxHistory('4', '0x123', { type: FilterType.INCOMING, token_address: '0x456' })
+
+      expect(spy).toHaveBeenCalledWith('4', '0x123', { token_address: '0x456' }, undefined)
+    })
+
+    it('fetches multisig transfers according to type', async () => {
+      const spy = jest.spyOn(gatewaySDK, 'getMultisigTransactions')
+
+      await _getTxHistory('4', '0x123', { type: FilterType.MULTISIG, to: '0x456' })
+
+      expect(spy).toHaveBeenCalledWith('4', '0x123', { to: '0x456', executed: 'true' }, undefined)
+    })
+
+    it('fetches module transfers according to type', async () => {
+      const spy = jest.spyOn(gatewaySDK, 'getModuleTransactions')
+
+      await _getTxHistory('4', '0x123', { type: FilterType.MODULE, to: '0x456' })
+
+      expect(spy).toHaveBeenCalledWith('4', '0x123', { to: '0x456' }, undefined)
+    })
+
+    it('fetches historical transfers by default', async () => {
+      const spy = jest.spyOn(gatewaySDK, 'getTransactionHistory')
+
+      await _getTxHistory('4', '0x123')
+
+      expect(spy).toHaveBeenCalledWith('4', '0x123', undefined)
+    })
+  })
+
+  describe('getHistoryPageUrl', () => {
+    it('returns the pageUrl when a falsy pageUrl is provided', () => {
+      // SDK types should allow for `null` in TransactionListPage['next' | 'previous'] as it's returned by gateway
+      expect(_getHistoryPageUrl(null as unknown as undefined, { type: FilterType.INCOMING })).toBe(null)
+    })
+
+    it('returns the pageUrl when a no filter is provided', () => {
+      expect(_getHistoryPageUrl('http://test123.com', undefined)).toBe('http://test123.com')
+      expect(_getHistoryPageUrl('http://test456.com', {})).toBe('http://test456.com')
+    })
+
+    it('returns the pageUrl if it is an invalid URL', () => {
+      expect(_getHistoryPageUrl('test123', { type: FilterType.INCOMING })).toBe('test123')
+    })
+
+    it('appends only defined filter values to the pageUrl', () => {
+      expect(_getHistoryPageUrl('http://test123.com', { type: FilterType.INCOMING, value: undefined })).toBe(
+        'http://test123.com/?type=Incoming',
+      )
+      expect(
+        _getHistoryPageUrl('http://test456.com', { type: FilterType.MULTISIG, execution_date__gte: undefined }),
+      ).toBe('http://test456.com/?type=Outgoing')
+    })
+  })
+})

--- a/src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions.ts
+++ b/src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions.ts
@@ -26,7 +26,7 @@ export const _getTxHistory = async (
   safeAddress: string,
   filter?: FilterForm | Partial<FilterForm>,
   next?: string,
-) => {
+): Promise<TransactionListPage> => {
   let txListPage: TransactionListPage = {
     next: undefined,
     previous: undefined,

--- a/src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions.ts
+++ b/src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions.ts
@@ -131,9 +131,7 @@ export const loadHistoryTransactions = async (
       historyPointers[chainId] = {}
     }
 
-    if (!historyPointers[chainId][safeAddress]) {
-      historyPointers[chainId][safeAddress] = getHistoryPointer(next, previous, filter)
-    }
+    historyPointers[chainId][safeAddress] = getHistoryPointer(next, previous, filter)
 
     return results
   } catch (e) {

--- a/src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions.ts
+++ b/src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions.ts
@@ -55,7 +55,7 @@ export const _getTxHistory = async (
 }
 
 export const _getHistoryPageUrl = (pageUrl?: string, filter?: FilterForm | Partial<FilterForm>): undefined | string => {
-  if (!pageUrl || !filter) {
+  if (!pageUrl || !filter || Object.keys(filter).length === 0) {
     return pageUrl
   }
 
@@ -68,7 +68,7 @@ export const _getHistoryPageUrl = (pageUrl?: string, filter?: FilterForm | Parti
   }
 
   Object.entries(filter)
-    .filter(([, value]) => Boolean(value))
+    .filter(([, value]) => value !== undefined)
     .forEach(([key, value]) => {
       url.searchParams.set(key, String(value))
     })

--- a/src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions.ts
+++ b/src/logic/safe/store/actions/transactions/fetchTransactions/loadGatewayTransactions.ts
@@ -131,7 +131,9 @@ export const loadHistoryTransactions = async (
       historyPointers[chainId] = {}
     }
 
-    historyPointers[chainId][safeAddress] = getHistoryPointer(next, previous, filter)
+    if (!historyPointers[chainId][safeAddress]) {
+      historyPointers[chainId][safeAddress] = getHistoryPointer(next, previous, filter)
+    }
 
     return results
   } catch (e) {

--- a/src/routes/safe/components/Transactions/TxList/Filter/index.tsx
+++ b/src/routes/safe/components/Transactions/TxList/Filter/index.tsx
@@ -165,7 +165,8 @@ const Filter = (): ReactElement => {
     return () => {
       unsubscribe()
     }
-  }, [history, chainId, dispatch, filterType, pathname, safeAddress])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const onSubmit = (filter: FilterForm) => {
     // Don't apply the same filter twice

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -17,7 +17,7 @@ export const SAFE_APPS_RPC_TOKEN = process.env.REACT_APP_SAFE_APPS_RPC_INFURA_TO
 export const LATEST_SAFE_VERSION = process.env.REACT_APP_LATEST_SAFE_VERSION || '1.3.0'
 export const APP_VERSION = process.env.REACT_APP_APP_VERSION || 'not-defined'
 export const COLLECTIBLES_SOURCE = process.env.REACT_APP_COLLECTIBLES_SOURCE || 'Gnosis'
-export const SAFE_POLLING_INTERVAL = process.env.NODE_ENV === 'test' ? 4500 : 15000
+export const SAFE_POLLING_INTERVAL = process.env.NODE_ENV === 'test' ? 4500 : 4000
 export const ETHERSCAN_API_KEY = process.env.REACT_APP_ETHERSCAN_API_KEY || ''
 export const ETHGASSTATION_API_KEY = process.env.REACT_APP_ETHGASSTATION_API_KEY
 export const IPFS_GATEWAY = process.env.REACT_APP_IPFS_GATEWAY

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -17,7 +17,7 @@ export const SAFE_APPS_RPC_TOKEN = process.env.REACT_APP_SAFE_APPS_RPC_INFURA_TO
 export const LATEST_SAFE_VERSION = process.env.REACT_APP_LATEST_SAFE_VERSION || '1.3.0'
 export const APP_VERSION = process.env.REACT_APP_APP_VERSION || 'not-defined'
 export const COLLECTIBLES_SOURCE = process.env.REACT_APP_COLLECTIBLES_SOURCE || 'Gnosis'
-export const SAFE_POLLING_INTERVAL = process.env.NODE_ENV === 'test' ? 4500 : 4000
+export const SAFE_POLLING_INTERVAL = process.env.NODE_ENV === 'test' ? 4500 : 15000
 export const ETHERSCAN_API_KEY = process.env.REACT_APP_ETHERSCAN_API_KEY || ''
 export const ETHGASSTATION_API_KEY = process.env.REACT_APP_ETHGASSTATION_API_KEY
 export const IPFS_GATEWAY = process.env.REACT_APP_IPFS_GATEWAY


### PR DESCRIPTION
## What it solves
History pointers polling `next`

## How this PR fixes it
`loadHistoryTransactions` has been split back to `loadHistoryTransactions` and `loadPagedHistoryTransactions`, the latter used for loading `next`+ `pageUrl`s.

## How to test it
1. Open a Safe with a large history, scroll to the second page. Enable a filter that also has a large amount. Observe the correct endpoints was queried and that is is correctly paginated. Clearing the filter should return to the history results, which should also be paginated correctly.
2. Open a Safe with a large history, create and execute a transaction. Observe the transaction no longer remains pending but moves to the history when successfully indexed.