### PR TITLE
feat: add links to current notifications

### DIFF
--- a/src/logic/notifications/notificationTypes.ts
+++ b/src/logic/notifications/notificationTypes.ts
@@ -32,8 +32,6 @@ enum NOTIFICATION_IDS {
   TX_CONFIRMATION_FAILED_MSG,
   TX_FETCH_SIGNATURES_ERROR_MSG,
   SAFE_APPS_FETCH_ERROR_MSG,
-  SAFE_NAME_CHANGED_MSG,
-  OWNER_NAME_CHANGE_EXECUTED_MSG,
   SIGN_SETTINGS_CHANGE_MSG,
   SETTINGS_CHANGE_REJECTED_MSG,
   SETTINGS_CHANGE_EXECUTED_MSG,
@@ -120,17 +118,6 @@ export const NOTIFICATIONS: Record<keyof typeof NOTIFICATION_IDS, Notification> 
   SAFE_APPS_FETCH_ERROR_MSG: {
     message: 'Error fetching the Safe Apps, please refresh the page',
     options: { variant: VARIANT.ERROR, autoHideDuration: shortDuration },
-  },
-  // Safe Name
-  SAFE_NAME_CHANGED_MSG: {
-    message: 'Safe name changed',
-    options: { variant: VARIANT.SUCCESS, autoHideDuration: shortDuration },
-  },
-
-  // Owner Name
-  OWNER_NAME_CHANGE_EXECUTED_MSG: {
-    message: 'Owner name changed',
-    options: { variant: VARIANT.SUCCESS, autoHideDuration: shortDuration },
   },
 
   // Settings

--- a/src/logic/safe/store/middleware/notificationsMiddleware.ts
+++ b/src/logic/safe/store/middleware/notificationsMiddleware.ts
@@ -82,6 +82,7 @@ const notificationsMiddleware =
           action.payload as unknown as HistoryPayload,
           userAddress,
           safesMap,
+          currentShortName,
         )
         // if we have a notification, dispatch it depending on transaction's status
         executedTxNotification && dispatch(showNotification(executedTxNotification))

--- a/src/logic/safe/store/middleware/notificationsMiddleware.ts
+++ b/src/logic/safe/store/middleware/notificationsMiddleware.ts
@@ -3,7 +3,7 @@ import { AnyAction } from 'redux'
 import { TransactionListItem, Transaction, TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
 
 import { NOTIFICATIONS } from 'src/logic/notifications'
-import { closeNotification, showNotification } from 'src/logic/notifications/store/notifications'
+import { showNotification } from 'src/logic/notifications/store/notifications'
 import { getAwaitingGatewayTransactions } from 'src/logic/safe/transactions/awaitingTransactions'
 import { getSafeVersionInfo } from 'src/logic/safe/utils/safeVersion'
 import { isUserAnOwner } from 'src/logic/wallets/ethAddresses'
@@ -19,21 +19,15 @@ import { isTransactionSummary } from 'src/logic/safe/store/models/types/gateway.
 import { loadFromStorage, saveToStorage } from 'src/utils/storage'
 import { store as reduxStore } from 'src/store/index'
 import { HistoryPayload } from 'src/logic/safe/store/reducer/gatewayTransactions'
-import { history, generateSafeRoute, SAFE_ROUTES } from 'src/routes/routes'
+import { generateSafeRoute, SAFE_ROUTES } from 'src/routes/routes'
 import { isTxPending } from 'src/logic/safe/store/selectors/pendingTransactions'
 import { PROVIDER_ACTIONS } from 'src/logic/wallets/store/actions'
 import { ADD_CURRENT_SAFE_ADDRESS } from 'src/logic/currentSession/store/actions/addCurrentSafeAddress'
 
 const LAST_TIME_USED_LOGGED_IN_ID = 'LAST_TIME_USED_LOGGED_IN_ID'
 
-const sendAwaitingTransactionNotification = (
-  dispatch,
-  safeAddress,
-  awaitingTxsSubmissionDateList,
-  notificationKey,
-  notificationClickedCb,
-): void => {
-  if (!dispatch || !safeAddress || !awaitingTxsSubmissionDateList || !notificationKey) {
+const sendAwaitingTransactionNotification = (dispatch, safeAddress, awaitingTxsSubmissionDateList, link): void => {
+  if (!dispatch || !safeAddress || !awaitingTxsSubmissionDateList) {
     return
   }
   if (awaitingTxsSubmissionDateList.length === 0) {
@@ -56,11 +50,7 @@ const sendAwaitingTransactionNotification = (
   dispatch(
     showNotification({
       ...NOTIFICATIONS.TX_WAITING_MSG,
-      options: {
-        ...NOTIFICATIONS.TX_WAITING_MSG.options,
-        onClick: notificationClickedCb,
-        key: notificationKey,
-      },
+      link,
     }),
   )
 
@@ -122,25 +112,15 @@ const notificationsMiddleware =
           break
         }
 
-        const notificationKey = `${safeAddress}-awaiting`
-
-        const onNotificationClicked = () => {
-          dispatch(closeNotification({ key: notificationKey }))
-          history.push(
-            generateSafeRoute(SAFE_ROUTES.TRANSACTIONS_HISTORY, {
-              shortName: currentShortName,
-              safeAddress,
-            }),
-          )
+        const link = {
+          to: generateSafeRoute(SAFE_ROUTES.TRANSACTIONS_QUEUE, {
+            shortName: currentShortName,
+            safeAddress,
+          }),
+          title: 'Transaction Queue',
         }
 
-        sendAwaitingTransactionNotification(
-          dispatch,
-          safeAddress,
-          awaitingTxsSubmissionDateList,
-          notificationKey,
-          onNotificationClicked,
-        )
+        sendAwaitingTransactionNotification(dispatch, safeAddress, awaitingTxsSubmissionDateList, link)
 
         break
       }
@@ -156,26 +136,19 @@ const notificationsMiddleware =
         const isUserOwner = grantedSelector(state)
         const version = await getSafeVersionInfo(safe.currentVersion)
 
-        const notificationKey = `${curSafeAddress}-update`
-        const onNotificationClicked = () => {
-          dispatch(closeNotification({ key: notificationKey }))
-          history.push(
-            generateSafeRoute(SAFE_ROUTES.SETTINGS_DETAILS, {
-              shortName: currentShortName,
-              safeAddress: curSafeAddress,
-            }),
-          )
+        const link = {
+          to: generateSafeRoute(SAFE_ROUTES.SETTINGS_DETAILS, {
+            shortName: currentShortName,
+            safeAddress: curSafeAddress,
+          }),
+          title: 'Update Safe',
         }
 
         if (version?.needUpdate && isUserOwner) {
           dispatch(
             showNotification({
               ...NOTIFICATIONS.SAFE_NEW_VERSION_AVAILABLE,
-              options: {
-                ...NOTIFICATIONS.SAFE_NEW_VERSION_AVAILABLE.options,
-                key: notificationKey,
-                onClick: onNotificationClicked,
-              },
+              link,
             }),
           )
         }

--- a/src/logic/safe/transactions/__tests__/pendingTxMonitor.test.ts
+++ b/src/logic/safe/transactions/__tests__/pendingTxMonitor.test.ts
@@ -69,10 +69,17 @@ describe('PendingTxMonitor', () => {
 
       const dispatchSpy = jest.spyOn(store.store, 'dispatch').mockImplementation(() => jest.fn())
 
-      await PendingTxMonitor.monitorTx(0, 'fakeTxId', 'fakeTxHash', {
-        numOfAttempts: 1,
-        startingDelay: 0,
-        timeMultiple: 0,
+      await PendingTxMonitor.monitorTx({
+        block: 0,
+        txId: 'fakeTxId',
+        txHash: 'fakeTxHash',
+        safeAddress: '0x0000000000000000000000000000000000000000',
+        shortName: 'rin',
+        options: {
+          numOfAttempts: 1,
+          startingDelay: 0,
+          timeMultiple: 0,
+        },
       })
 
       expect(dispatchSpy).not.toBeCalled()
@@ -82,10 +89,17 @@ describe('PendingTxMonitor', () => {
 
       const dispatchSpy = jest.spyOn(store.store, 'dispatch').mockImplementation(() => jest.fn())
 
-      await PendingTxMonitor.monitorTx(0, 'fakeTxId', 'fakeTxHash', {
-        numOfAttempts: 1,
-        startingDelay: 0,
-        timeMultiple: 0,
+      await PendingTxMonitor.monitorTx({
+        block: 0,
+        txId: 'fakeTxId',
+        txHash: 'fakeTxHash',
+        safeAddress: '0x0000000000000000000000000000000000000000',
+        shortName: 'rin',
+        options: {
+          numOfAttempts: 1,
+          startingDelay: 0,
+          timeMultiple: 0,
+        },
       })
 
       expect(dispatchSpy).toBeCalledWith({
@@ -99,10 +113,17 @@ describe('PendingTxMonitor', () => {
 
       const dispatchSpy = jest.spyOn(store.store, 'dispatch').mockImplementation(() => jest.fn())
 
-      await PendingTxMonitor.monitorTx(0, 'fakeTxId', 'fakeTxHash', {
-        numOfAttempts: 1,
-        startingDelay: 0,
-        timeMultiple: 0,
+      await PendingTxMonitor.monitorTx({
+        block: 0,
+        txId: 'fakeTxId',
+        txHash: 'fakeTxHash',
+        safeAddress: '0x0000000000000000000000000000000000000000',
+        shortName: 'rin',
+        options: {
+          numOfAttempts: 1,
+          startingDelay: 0,
+          timeMultiple: 0,
+        },
       })
 
       expect(dispatchSpy).toHaveBeenCalledTimes(1)
@@ -117,10 +138,17 @@ describe('PendingTxMonitor', () => {
 
       const dispatchSpy = jest.spyOn(store.store, 'dispatch').mockImplementation(() => jest.fn())
 
-      await PendingTxMonitor.monitorTx(0, 'fakeTxId', 'fakeTxHash', {
-        numOfAttempts: 1,
-        startingDelay: 0,
-        timeMultiple: 0,
+      await PendingTxMonitor.monitorTx({
+        block: 0,
+        txId: 'fakeTxId',
+        txHash: 'fakeTxHash',
+        safeAddress: '0x0000000000000000000000000000000000000000',
+        shortName: 'rin',
+        options: {
+          numOfAttempts: 1,
+          startingDelay: 0,
+          timeMultiple: 0,
+        },
       })
 
       expect(dispatchSpy).toHaveBeenCalledTimes(2)
@@ -131,10 +159,17 @@ describe('PendingTxMonitor', () => {
 
       const dispatchSpy = jest.spyOn(store.store, 'dispatch').mockImplementation(() => jest.fn())
 
-      await PendingTxMonitor.monitorTx(0, 'fakeTxId', 'fakeTxHash', {
-        numOfAttempts: 1,
-        startingDelay: 0,
-        timeMultiple: 0,
+      await PendingTxMonitor.monitorTx({
+        block: 0,
+        txId: 'fakeTxId',
+        txHash: 'fakeTxHash',
+        safeAddress: '0x0000000000000000000000000000000000000000',
+        shortName: 'rin',
+        options: {
+          numOfAttempts: 1,
+          startingDelay: 0,
+          timeMultiple: 0,
+        },
       })
 
       expect(dispatchSpy).toHaveBeenCalledTimes(2)

--- a/src/logic/safe/utils/aboutToExecuteTx.ts
+++ b/src/logic/safe/utils/aboutToExecuteTx.ts
@@ -6,6 +6,8 @@ import { HistoryPayload } from 'src/logic/safe/store/reducer/gatewayTransactions
 import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
 import { SafesMap } from 'src/logic/safe/store/reducer/types/safe'
 import { Notification } from 'src/logic/notifications/notificationTypes'
+import { getPrefixedSafeAddressSlug, SAFE_ADDRESS_SLUG, SAFE_ROUTES, TRANSACTION_ID_SLUG } from 'src/routes/routes'
+import { generatePath } from 'react-router-dom'
 
 let nonce: number | undefined
 
@@ -17,6 +19,7 @@ export const getNotification = (
   { safeAddress, values }: HistoryPayload,
   userAddress: string,
   safes: SafesMap,
+  shortName: string,
 ): undefined | Notification => {
   const currentSafe = safes.get(safeAddress)
 
@@ -44,7 +47,12 @@ export const getNotification = (
       // reset nonce value
       setNonce(undefined)
 
-      return notification
+      const to = generatePath(SAFE_ROUTES.TRANSACTIONS_SINGULAR, {
+        [SAFE_ADDRESS_SLUG]: getPrefixedSafeAddressSlug({ safeAddress, shortName }),
+        [TRANSACTION_ID_SLUG]: executedTx.id,
+      })
+
+      return { ...notification, link: { title: 'Transaction', to } }
     }
   }
 }

--- a/src/routes/safe/components/Settings/ManageOwners/EditOwnerModal/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/EditOwnerModal/index.tsx
@@ -12,8 +12,6 @@ import Modal, { Modal as GenericModal } from 'src/components/Modal'
 import PrefixedEthHashInfo from 'src/components/PrefixedEthHashInfo'
 import { makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
 import { addressBookAddOrUpdate } from 'src/logic/addressBook/store/actions'
-import { NOTIFICATIONS } from 'src/logic/notifications'
-import { showNotification } from 'src/logic/notifications/store/notifications'
 import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/screens/ModalHeader'
 import { OwnerData } from 'src/routes/safe/components/Settings/ManageOwners/dataFetcher'
 
@@ -38,7 +36,6 @@ export const EditOwnerModal = ({ isOpen, onClose, owner }: OwnProps): React.Reac
     // Update the value only if the ownerName really changed
     if (ownerName !== owner.name) {
       dispatch(addressBookAddOrUpdate(makeAddressBookEntry({ address: owner.address, name: ownerName, chainId })))
-      dispatch(showNotification(NOTIFICATIONS.OWNER_NAME_CHANGE_EXECUTED_MSG))
     }
     onClose()
   }

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -19,8 +19,6 @@ import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import { makeAddressBookEntry } from 'src/logic/addressBook/model/addressBook'
 import { addressBookAddOrUpdate } from 'src/logic/addressBook/store/actions'
-import { showNotification } from 'src/logic/notifications/store/notifications'
-import { NOTIFICATIONS } from 'src/logic/notifications'
 import { sameAddress } from 'src/logic/wallets/ethAddresses'
 import { UpdateSafeModal } from 'src/routes/safe/components/Settings/UpdateSafeModal'
 import { grantedSelector } from 'src/routes/safe/container/selector'
@@ -89,8 +87,6 @@ const SafeDetails = (): ReactElement => {
     )
     // setting `loadedViaUrl` to `false` as setting a safe's name is considered to intentionally add the safe
     dispatch(updateSafe({ address: safeAddress, loadedViaUrl: false }))
-
-    dispatch(showNotification(NOTIFICATIONS.SAFE_NAME_CHANGED_MSG))
   }
 
   const handleUpdateSafe = () => {

--- a/src/routes/safe/components/Transactions/TxList/hooks/useActionButtonsHandlers.ts
+++ b/src/routes/safe/components/Transactions/TxList/hooks/useActionButtonsHandlers.ts
@@ -18,6 +18,9 @@ import { NOTIFICATIONS } from 'src/logic/notifications'
 import useTxStatus from 'src/logic/hooks/useTxStatus'
 import { trackEvent } from 'src/utils/googleTagManager'
 import { TX_LIST_EVENTS } from 'src/utils/events/txList'
+import { generatePath } from 'react-router-dom'
+import useSafeAddress from 'src/logic/currentSession/hooks/useSafeAddress'
+import { SAFE_ROUTES, SAFE_ADDRESS_SLUG, getPrefixedSafeAddressSlug, TRANSACTION_ID_SLUG } from 'src/routes/routes'
 
 type ActionButtonsHandlers = {
   canCancel: boolean
@@ -38,6 +41,7 @@ export const useActionButtonsHandlers = (transaction: Transaction): ActionButton
   const { canCancel, canConfirmThenExecute, canExecute } = useTransactionActions(transaction)
   const txStatus = useTxStatus(transaction)
   const isPending = txStatus === LocalTransactionStatus.PENDING
+  const { shortName, safeAddress } = useSafeAddress()
 
   const handleConfirmButtonClick = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -48,7 +52,17 @@ export const useActionButtonsHandlers = (transaction: Transaction): ActionButton
           (canExecute && details.confirmationsRequired > details.confirmations.length) ||
           (canConfirmThenExecute && details.confirmationsRequired - 1 > details.confirmations.length)
         ) {
-          dispatch(showNotification(NOTIFICATIONS.TX_FETCH_SIGNATURES_ERROR_MSG))
+          const deeplink = generatePath(SAFE_ROUTES.TRANSACTIONS_SINGULAR, {
+            [SAFE_ADDRESS_SLUG]: getPrefixedSafeAddressSlug({ shortName, safeAddress }),
+            [TRANSACTION_ID_SLUG]: transaction.id,
+          })
+
+          dispatch(
+            showNotification({
+              ...NOTIFICATIONS.TX_FETCH_SIGNATURES_ERROR_MSG,
+              link: { to: deeplink, title: 'Transaction' },
+            }),
+          )
           return
         }
       }
@@ -61,7 +75,7 @@ export const useActionButtonsHandlers = (transaction: Transaction): ActionButton
         transactionId: transaction.id,
       })
     },
-    [canConfirmThenExecute, canExecute, dispatch, transaction.id, transaction.txDetails],
+    [canConfirmThenExecute, canExecute, dispatch, transaction.id, transaction.txDetails, safeAddress, shortName],
   )
 
   const handleCancelButtonClick = useCallback(


### PR DESCRIPTION
## What it solves
Adding links to current notifications

## How this PR fixes it
All current notifications that could have links added to them, i.e. when a Safe requires an update, now receive and render links.

## How to test it
- Open a Safe that requires an update and observe the notification now including a link.

## Screenshots
![current links](https://user-images.githubusercontent.com/20442784/175041785-824e0ae5-7902-4000-adf9-da4863aff449.gif)