### PR TITLE
Fix: mastercopy link size

### DIFF
--- a/src/components/AppLayout/InvalidMasterCopyError/index.tsx
+++ b/src/components/AppLayout/InvalidMasterCopyError/index.tsx
@@ -38,7 +38,7 @@ export const InvalidMasterCopyError = (): React.ReactElement | null => {
     <MuiAlert severity="error" onClose={() => setShowMasterCopyError(false)}>
       This Safe was created with an unsupported base contract. The web interface might not work correctly. We recommend
       using the{' '}
-      <Link href={CLI_LINK} size="xl" target="_blank" rel="noopener noreferrer">
+      <Link href={CLI_LINK} size="lg" target="_blank" rel="noopener noreferrer">
         command line interface
       </Link>{' '}
       instead.


### PR DESCRIPTION
The xl size of the link looks weird:
<img width="443" alt="Screenshot 2022-06-23 at 17 55 13" src="https://user-images.githubusercontent.com/381895/175342541-d352d699-65f4-457c-aebb-7a04cf405390.png">

I've changed it to `lg` to match the text font:
<img width="416" alt="Screenshot 2022-06-23 at 17 55 02" src="https://user-images.githubusercontent.com/381895/175342601-f48c1d1d-67ec-41f3-b1d3-e084eedf691e.png">

