### PR TITLE
feat: add article to delegate call warnings

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/AlertTooltipWarning.tsx
+++ b/src/routes/safe/components/Transactions/TxList/AlertTooltipWarning.tsx
@@ -37,7 +37,7 @@ type Props = {
 }
 
 const AlertTooltipWarning = ({ tooltip, message, isWarning = false }: Props): ReactElement => (
-  <StyledTooltip title={tooltip} arrow placement="top-start">
+  <StyledTooltip title={tooltip} arrow placement="top-start" interactive>
     <StyledAlert severity="info" $isWarning={isWarning}>
       {message}
     </StyledAlert>

--- a/src/routes/safe/components/Transactions/TxList/DelegateCallWarning.tsx
+++ b/src/routes/safe/components/Transactions/TxList/DelegateCallWarning.tsx
@@ -1,10 +1,24 @@
 import { ReactElement } from 'react'
 
+import Link from 'src/components/layout/Link'
 import AlertTooltipWarning from './AlertTooltipWarning'
+
+const UNEXPECTED_DELEGATE_ARTICLE =
+  'https://help.gnosis-safe.io/en/articles/6302452-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction'
 
 const DelegateCallWarning = ({ showWarning = false }: { showWarning: boolean }): ReactElement => (
   <AlertTooltipWarning
-    tooltip="This transaction calls a smart contract that will be able to modify your Safe."
+    tooltip={
+      <>
+        This transaction calls a smart contract that will be able to modify your Safe.
+        {showWarning && (
+          <>
+            <br />
+            <Link href={UNEXPECTED_DELEGATE_ARTICLE}>Learn more</Link>
+          </>
+        )}
+      </>
+    }
     message={showWarning ? 'Unexpected Delegate Call' : 'Delegate Call'}
     isWarning={showWarning}
   />


### PR DESCRIPTION
## What it solves
Further resolves #3471

## How this PR fixes it
A link to the article explaining unexpected delegate calls has been added to the warning tooltips shown.

## How to test it
Open an unexpected delegate call (`rin:0x73a7AA145338587f7aB7f63c06d187C85dF4727e/transactions/multisig_0x73a7AA145338587f7aB7f63c06d187C85dF4727e_0xba28109747222d6cfb7f0fb75f03d49957e343674bc116162b038e244dbcc6d6`), hover over the warning and observe the link in the tooltip.

## Screenshots
![image](https://user-images.githubusercontent.com/20442784/176141272-ed1401da-3585-43cf-8b44-771dfc9b6af7.png)