### PR TITLE
fix: enable date filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prettier": "prettier './src/**/*.{js,jsx,ts,tsx}'",
     "start": "rescripts start",
     "start:docker": "docker-compose build && docker-compose up",
-    "test": "cross-env REACT_APP_ENV=test rescripts test --env=jsdom",
+    "test": "cross-env TZ=Europe/Berlin REACT_APP_ENV=test rescripts test --env=jsdom",
     "test:coverage": "REACT_APP_ENV=test yarn test --coverage --watchAll=false",
     "test:ci": "REACT_APP_ENV=test yarn test --ci --coverage --json --watchAll=false --testLocationInResults --runInBand --outputFile=jest.results.json",
     "update-mocks": "./scripts/update-mocks.sh",

--- a/src/routes/safe/components/Transactions/TxList/Filter/RHFTextField.tsx
+++ b/src/routes/safe/components/Transactions/TxList/Filter/RHFTextField.tsx
@@ -10,19 +10,9 @@ type Props<T> = {
   rules?: UseControllerProps<T>['rules']
   label: string
   type?: HTMLInputTypeAttribute
-  // To disable date fields
-  disabled?: boolean
-  endAdornment?: ReactElement
 }
 
-const RHFTextField = <T extends FieldValues>({
-  name,
-  rules,
-  control,
-  type,
-  endAdornment = undefined,
-  ...props
-}: Props<T>): ReactElement => {
+const RHFTextField = <T extends FieldValues>({ name, rules, control, type, ...props }: Props<T>): ReactElement => {
   const {
     field: { ref, value, ...field },
     fieldState: { error },
@@ -43,7 +33,6 @@ const RHFTextField = <T extends FieldValues>({
       error={!!error}
       helperText={getFilterHelperText(value, error)}
       InputLabelProps={{ shrink: type === 'date' || !!value }}
-      InputProps={{ endAdornment }}
     />
   )
 }

--- a/src/routes/safe/components/Transactions/TxList/Filter/__tests__/utils.test.ts
+++ b/src/routes/safe/components/Transactions/TxList/Filter/__tests__/utils.test.ts
@@ -112,14 +112,14 @@ describe('utils', () => {
   describe('getIncomingFilter', () => {
     it('should extract the incoming filter values from the filter, correctly formatted', () => {
       const filter = {
-        execution_date__gte: '1970-01-01',
+        execution_date__gte: '2000-01-01',
         execution_date__lte: '2000-01-01',
         type: FilterType.INCOMING,
         value: '123',
       }
 
       expect(utils.getIncomingFilter(filter)).toEqual({
-        execution_date__gte: '1969-12-31T23:00:00.000Z',
+        execution_date__gte: '1999-12-31T23:00:00.000Z',
         execution_date__lte: '2000-01-01T22:59:59.999Z',
         value: '123000000000000000000',
       })
@@ -130,7 +130,7 @@ describe('utils', () => {
       const filter = {
         __to: 'fakeaddress.eth',
         to: '0x1234567890123456789012345678901234567890',
-        execution_date__gte: '1970-01-01',
+        execution_date__gte: '2000-01-01',
         execution_date__lte: '2000-01-01',
         type: FilterType.MULTISIG,
         value: '123',
@@ -139,7 +139,7 @@ describe('utils', () => {
 
       expect(utils.getMultisigFilter(filter)).toEqual({
         to: '0x1234567890123456789012345678901234567890',
-        execution_date__gte: '1969-12-31T23:00:00.000Z',
+        execution_date__gte: '1999-12-31T23:00:00.000Z',
         execution_date__lte: '2000-01-01T22:59:59.999Z',
         value: '123000000000000000000',
         nonce: '123',
@@ -149,7 +149,7 @@ describe('utils', () => {
       const filter = {
         __to: 'fakeaddress.eth',
         to: '0x1234567890123456789012345678901234567890',
-        execution_date__gte: '1970-01-01',
+        execution_date__gte: '2000-01-01',
         execution_date__lte: '2000-01-01',
         type: FilterType.MULTISIG,
         value: '123',
@@ -158,7 +158,7 @@ describe('utils', () => {
 
       expect(utils.getMultisigFilter(filter, true)).toEqual({
         to: '0x1234567890123456789012345678901234567890',
-        execution_date__gte: '1969-12-31T23:00:00.000Z',
+        execution_date__gte: '1999-12-31T23:00:00.000Z',
         execution_date__lte: '2000-01-01T22:59:59.999Z',
         value: '123000000000000000000',
         nonce: '123',

--- a/src/routes/safe/components/Transactions/TxList/Filter/__tests__/utils.test.ts
+++ b/src/routes/safe/components/Transactions/TxList/Filter/__tests__/utils.test.ts
@@ -120,7 +120,7 @@ describe('utils', () => {
 
       expect(utils.getIncomingFilter(filter)).toEqual({
         execution_date__gte: '1970-01-01T00:00:00.000Z',
-        execution_date__lte: '2000-01-01T00:00:00.000Z',
+        execution_date__lte: '2000-01-01T23:59:59.999Z',
         value: '123000000000000000000',
       })
     })
@@ -140,7 +140,7 @@ describe('utils', () => {
       expect(utils.getMultisigFilter(filter)).toEqual({
         to: '0x1234567890123456789012345678901234567890',
         execution_date__gte: '1970-01-01T00:00:00.000Z',
-        execution_date__lte: '2000-01-01T00:00:00.000Z',
+        execution_date__lte: '2000-01-01T23:59:59.999Z',
         value: '123000000000000000000',
         nonce: '123',
       })
@@ -159,7 +159,7 @@ describe('utils', () => {
       expect(utils.getMultisigFilter(filter, true)).toEqual({
         to: '0x1234567890123456789012345678901234567890',
         execution_date__gte: '1970-01-01T00:00:00.000Z',
-        execution_date__lte: '2000-01-01T00:00:00.000Z',
+        execution_date__lte: '2000-01-01T23:59:59.999Z',
         value: '123000000000000000000',
         nonce: '123',
         executed: 'true',

--- a/src/routes/safe/components/Transactions/TxList/Filter/__tests__/utils.test.ts
+++ b/src/routes/safe/components/Transactions/TxList/Filter/__tests__/utils.test.ts
@@ -119,8 +119,8 @@ describe('utils', () => {
       }
 
       expect(utils.getIncomingFilter(filter)).toEqual({
-        execution_date__gte: '1970-01-01T00:00:00.000Z',
-        execution_date__lte: '2000-01-01T23:59:59.999Z',
+        execution_date__gte: '1969-12-31T23:00:00.000Z',
+        execution_date__lte: '2000-01-01T22:59:59.999Z',
         value: '123000000000000000000',
       })
     })
@@ -139,8 +139,8 @@ describe('utils', () => {
 
       expect(utils.getMultisigFilter(filter)).toEqual({
         to: '0x1234567890123456789012345678901234567890',
-        execution_date__gte: '1970-01-01T00:00:00.000Z',
-        execution_date__lte: '2000-01-01T23:59:59.999Z',
+        execution_date__gte: '1969-12-31T23:00:00.000Z',
+        execution_date__lte: '2000-01-01T22:59:59.999Z',
         value: '123000000000000000000',
         nonce: '123',
       })
@@ -158,8 +158,8 @@ describe('utils', () => {
 
       expect(utils.getMultisigFilter(filter, true)).toEqual({
         to: '0x1234567890123456789012345678901234567890',
-        execution_date__gte: '1970-01-01T00:00:00.000Z',
-        execution_date__lte: '2000-01-01T23:59:59.999Z',
+        execution_date__gte: '1969-12-31T23:00:00.000Z',
+        execution_date__lte: '2000-01-01T22:59:59.999Z',
         value: '123000000000000000000',
         nonce: '123',
         executed: 'true',

--- a/src/routes/safe/components/Transactions/TxList/Filter/index.tsx
+++ b/src/routes/safe/components/Transactions/TxList/Filter/index.tsx
@@ -33,9 +33,6 @@ import { loadHistoryTransactions } from 'src/logic/safe/store/actions/transactio
 import { checksumAddress } from 'src/utils/checksumAddress'
 import { ChainId } from 'src/config/chain'
 import { Dispatch } from 'src/logic/safe/store/actions/types'
-import HourglassEmptyIcon from '@material-ui/icons/HourglassEmpty'
-import { IconButton, InputAdornment } from '@material-ui/core'
-import { Tooltip } from 'src/components/layout/Tooltip'
 import { isEqual } from 'lodash'
 
 export const FILTER_TYPE_FIELD_NAME = 'type'
@@ -182,8 +179,8 @@ const Filter = (): ReactElement => {
 
     const trackedFields = [
       FILTER_TYPE_FIELD_NAME,
-      // DATE_FROM_FIELD_NAME,
-      // DATE_TO_FIELD_NAME,
+      DATE_FROM_FIELD_NAME,
+      DATE_TO_FIELD_NAME,
       RECIPIENT_FIELD_NAME,
       AMOUNT_FIELD_NAME,
       TOKEN_ADDRESS_FIELD_NAME,
@@ -199,16 +196,6 @@ const Filter = (): ReactElement => {
 
     hideFilter()
   }
-
-  const comingSoonAdornment = (
-    <InputAdornment position="end">
-      <Tooltip title="Coming soon" arrow>
-        <IconButton>
-          <HourglassEmptyIcon />
-        </IconButton>
-      </Tooltip>
-    </InputAdornment>
-  )
 
   return (
     <>
@@ -246,19 +233,15 @@ const Filter = (): ReactElement => {
                           <StyledRHFTextField<FilterForm>
                             name={DATE_FROM_FIELD_NAME}
                             label="From"
-                            // type="date"
+                            type="date"
                             control={control}
-                            disabled
-                            endAdornment={comingSoonAdornment}
                           />
                           {/* @ts-expect-error - styled-components don't have strict types */}
                           <StyledRHFTextField<FilterForm>
                             name={DATE_TO_FIELD_NAME}
                             label="To"
-                            // type="date"
+                            type="date"
                             control={control}
-                            disabled
-                            endAdornment={comingSoonAdornment}
                           />
                           <RHFTextField<FilterForm>
                             name={AMOUNT_FIELD_NAME}

--- a/src/routes/safe/components/Transactions/TxList/Filter/index.tsx
+++ b/src/routes/safe/components/Transactions/TxList/Filter/index.tsx
@@ -125,7 +125,7 @@ const Filter = (): ReactElement => {
     defaultValues: initialValues,
     shouldUnregister: true,
   })
-  const { handleSubmit, reset, watch, control } = methods
+  const { handleSubmit, reset, watch, control, getValues } = methods
 
   const toggleFilter = () => {
     if (showFilter) {
@@ -235,6 +235,14 @@ const Filter = (): ReactElement => {
                             label="From"
                             type="date"
                             control={control}
+                            rules={{
+                              validate: (value) => {
+                                const to = getValues(DATE_TO_FIELD_NAME)
+                                if (value && to && value > to) {
+                                  return 'Cannot be after to date'
+                                }
+                              },
+                            }}
                           />
                           {/* @ts-expect-error - styled-components don't have strict types */}
                           <StyledRHFTextField<FilterForm>
@@ -242,6 +250,15 @@ const Filter = (): ReactElement => {
                             label="To"
                             type="date"
                             control={control}
+                            rules={{
+                              validate: (value) => {
+                                const from = getValues(DATE_FROM_FIELD_NAME)
+                                if (value && from && value < from) {
+                                  console.log('invalid')
+                                  return 'Cannot be before from date'
+                                }
+                              },
+                            }}
                           />
                           <RHFTextField<FilterForm>
                             name={AMOUNT_FIELD_NAME}

--- a/src/routes/safe/components/Transactions/TxList/Filter/utils.ts
+++ b/src/routes/safe/components/Transactions/TxList/Filter/utils.ts
@@ -81,15 +81,25 @@ const getTransactionFilter = ({
   execution_date__lte,
   value,
 }: Filter): Partial<IncomingFilter | OutgoingFilter> => {
-  const getLocalStartOfDay = (date: string): number => new Date(date).setHours(0, 0, 0, 0)
-  const getLocalEndOfDay = (date: string): number => new Date(date).setHours(23, 59, 59, 999)
+  const getStartOfDay = (date: string): string => {
+    const now = new Date(date)
+    const local = now.setUTCMinutes(now.getTimezoneOffset())
+    return new Date(local).toISOString()
+  }
+
+  const getEndOfDay = (date: string): string => {
+    const now = new Date(date)
+    const hourOffset = now.getTimezoneOffset() / 60
+    const local = now.setUTCHours(23 + hourOffset, 59, 59, 999)
+    return new Date(local).toISOString()
+  }
 
   return {
     ...(execution_date__gte && {
-      execution_date__gte: new Date(getLocalStartOfDay(execution_date__gte)).toISOString(),
+      execution_date__gte: getStartOfDay(execution_date__gte),
     }),
     ...(execution_date__lte && {
-      execution_date__lte: new Date(getLocalEndOfDay(execution_date__lte)).toISOString(),
+      execution_date__lte: getEndOfDay(execution_date__lte),
     }),
     ...(value && { value: toWei(value) }),
   }

--- a/src/routes/safe/components/Transactions/TxList/Filter/utils.ts
+++ b/src/routes/safe/components/Transactions/TxList/Filter/utils.ts
@@ -81,10 +81,15 @@ const getTransactionFilter = ({
   execution_date__lte,
   value,
 }: Filter): Partial<IncomingFilter | OutgoingFilter> => {
-  const getISOString = (date: string): string => new Date(date).toISOString()
+  const getStartOfDay = (date: string): number => new Date(date).setUTCHours(0, 0, 0, 0)
+  const getEndOfDay = (date: string): number => new Date(date).setUTCHours(23, 59, 59, 999)
   return {
-    ...(execution_date__gte && { execution_date__gte: getISOString(execution_date__gte) }),
-    ...(execution_date__lte && { execution_date__lte: getISOString(execution_date__lte) }),
+    ...(execution_date__gte && {
+      execution_date__gte: new Date(getStartOfDay(execution_date__gte)).toISOString(),
+    }),
+    ...(execution_date__lte && {
+      execution_date__lte: new Date(getEndOfDay(execution_date__lte)).toISOString(),
+    }),
     ...(value && { value: toWei(value) }),
   }
 }

--- a/src/routes/safe/components/Transactions/TxList/Filter/utils.ts
+++ b/src/routes/safe/components/Transactions/TxList/Filter/utils.ts
@@ -81,14 +81,15 @@ const getTransactionFilter = ({
   execution_date__lte,
   value,
 }: Filter): Partial<IncomingFilter | OutgoingFilter> => {
-  const getStartOfDay = (date: string): number => new Date(date).setUTCHours(0, 0, 0, 0)
-  const getEndOfDay = (date: string): number => new Date(date).setUTCHours(23, 59, 59, 999)
+  const getLocalStartOfDay = (date: string): number => new Date(date).setHours(0, 0, 0, 0)
+  const getLocalEndOfDay = (date: string): number => new Date(date).setHours(23, 59, 59, 999)
+
   return {
     ...(execution_date__gte && {
-      execution_date__gte: new Date(getStartOfDay(execution_date__gte)).toISOString(),
+      execution_date__gte: new Date(getLocalStartOfDay(execution_date__gte)).toISOString(),
     }),
     ...(execution_date__lte && {
-      execution_date__lte: new Date(getEndOfDay(execution_date__lte)).toISOString(),
+      execution_date__lte: new Date(getLocalEndOfDay(execution_date__lte)).toISOString(),
     }),
     ...(value && { value: toWei(value) }),
   }

--- a/src/routes/safe/components/Transactions/TxList/Filter/utils.ts
+++ b/src/routes/safe/components/Transactions/TxList/Filter/utils.ts
@@ -81,17 +81,17 @@ const getTransactionFilter = ({
   execution_date__lte,
   value,
 }: Filter): Partial<IncomingFilter | OutgoingFilter> => {
-  const getStartOfDay = (date: string): string => {
-    const now = new Date(date)
-    const local = now.setUTCMinutes(now.getTimezoneOffset())
-    return new Date(local).toISOString()
+  const getStartOfDay = (value: string): string => {
+    const date = new Date(value)
+    const utc = date.setUTCMinutes(date.getTimezoneOffset())
+    return new Date(utc).toISOString()
   }
 
-  const getEndOfDay = (date: string): string => {
-    const now = new Date(date)
-    const hourOffset = now.getTimezoneOffset() / 60
-    const local = now.setUTCHours(23 + hourOffset, 59, 59, 999)
-    return new Date(local).toISOString()
+  const getEndOfDay = (value: string): string => {
+    const date = new Date(value)
+    // 23:59:59.999 + offset
+    const utc = date.setUTCMinutes(23 * 60 + 59 + date.getTimezoneOffset(), 59, 999)
+    return new Date(utc).toISOString()
   }
 
   return {


### PR DESCRIPTION
## What it solves
Date filters, part of https://github.com/safe-global/safe-pm/issues/52 epic

## How this PR fixes it
The previously broken date filters have been fixed and are now enabled.

## How to test it
Open the historical transaction list and search by date range. Observe the filtered transactions matching those of the filtered dates.

## Analytics changes
To/from date periods are tracked.

## Screenshots
![filter](https://user-images.githubusercontent.com/20442784/176144012-3c6a580b-9951-4a0d-88ae-21a2b3e57367.gif)