### PR TITLE
Fix simulation text: batch -> transaction

### DIFF
--- a/src/routes/safe/components/Transactions/helpers/Simulation/SimulationResult.tsx
+++ b/src/routes/safe/components/Transactions/helpers/Simulation/SimulationResult.tsx
@@ -1,7 +1,8 @@
+import { ReactElement } from 'react'
+import styled from 'styled-components'
 import { Icon, Link, Text } from '@gnosis.pm/safe-react-components'
 import { Alert, AlertTitle } from '@material-ui/lab'
 import { FETCH_STATUS } from 'src/utils/requests'
-import styled from 'styled-components'
 import { TenderlySimulation } from './types'
 
 const StyledAlert = styled(Alert)`
@@ -35,56 +36,59 @@ export const SimulationResult = ({
   simulationLink,
   requestError,
   onClose,
-}: SimulationResultProps): React.ReactElement => {
-  const isErroneous = !!requestError || !simulation?.simulation.status
+}: SimulationResultProps): ReactElement | null => {
   const isSimulationFinished =
     simulationRequestStatus === FETCH_STATUS.SUCCESS || simulationRequestStatus === FETCH_STATUS.ERROR
 
+  // Loading
+  if (!isSimulationFinished) {
+    return null
+  }
+
+  // Error
+  if (requestError || !simulation?.simulation.status) {
+    return (
+      <StyledAlert severity="error" onClose={onClose} icon={<Icon type="alert" color="error" size="sm" />}>
+        <AlertTitle>
+          <Text color="error" size="lg">
+            <b>Failed</b>
+          </Text>
+        </AlertTitle>
+
+        {requestError ? (
+          <Text color="error" size="lg">
+            An unexpected error occurred during simulation: <b>{requestError}</b>
+          </Text>
+        ) : (
+          <Text color="inputFilled" size="lg">
+            The transaction failed during the simulation throwing error <b>{simulation?.transaction.error_message}</b>{' '}
+            in the contract at <b>{simulation?.transaction.error_info?.address}</b>. Full simulation report is available{' '}
+            <Link href={simulationLink} target="_blank" rel="noreferrer" size="lg">
+              <b>on Tenderly</b>
+            </Link>
+            .
+          </Text>
+        )}
+      </StyledAlert>
+    )
+  }
+
+  // Success
   return (
-    <>
-      {isSimulationFinished && (
-        <>
-          {isErroneous ? (
-            <StyledAlert severity="error" onClose={onClose} icon={<Icon type="alert" color="error" size="sm" />}>
-              <AlertTitle>
-                <Text color={'error'} size="lg">
-                  <b>Failed</b>
-                </Text>
-              </AlertTitle>
-              {requestError ? (
-                <Text color="error" size="lg">
-                  An unexpected error occurred during simulation: <b>{requestError}</b>
-                </Text>
-              ) : (
-                <Text color="inputFilled" size="lg">
-                  The batch failed during the simulation throwing error <b>{simulation?.transaction.error_message}</b>{' '}
-                  in the contract at <b>{simulation?.transaction.error_info?.address}</b>. Full simulation report is
-                  available{' '}
-                  <Link href={simulationLink} target="_blank" rel="noreferrer" size="lg">
-                    <b>on Tenderly</b>
-                  </Link>
-                  .
-                </Text>
-              )}
-            </StyledAlert>
-          ) : (
-            <StyledAlert severity="success" icon={<Icon type="check" color="primary" size="sm" />} onClose={onClose}>
-              <AlertTitle>
-                <Text color={'primary'} size="lg">
-                  <b>Success</b>
-                </Text>
-              </AlertTitle>
-              <Text color="inputFilled" size="lg">
-                The batch was successfully simulated. Full simulation report is available{' '}
-                <Link href={simulationLink} target="_blank" rel="noreferrer" size="lg">
-                  <b>on Tenderly</b>
-                </Link>
-                .
-              </Text>
-            </StyledAlert>
-          )}
-        </>
-      )}
-    </>
+    <StyledAlert severity="success" icon={<Icon type="check" color="primary" size="sm" />} onClose={onClose}>
+      <AlertTitle>
+        <Text color={'primary'} size="lg">
+          <b>Success</b>
+        </Text>
+      </AlertTitle>
+
+      <Text color="inputFilled" size="lg">
+        The transaction was successfully simulated. Full simulation report is available{' '}
+        <Link href={simulationLink} target="_blank" rel="noreferrer" size="lg">
+          <b>on Tenderly</b>
+        </Link>
+        .
+      </Text>
+    </StyledAlert>
   )
 }


### PR DESCRIPTION
## What it solves
Fixes this: https://github.com/safe-global/safe-react/pull/3925#issuecomment-1170028186

The simulation result should say "transaction", not "batch".

I also took the opportunity to refactor the result component slightly. Best reviewed with whitespace changes disabled: https://github.com/safe-global/safe-react/pull/4004/files?diff=split&w=1