### PR TITLE
fix: wrong notification labels

### DIFF
--- a/src/logic/safe/store/middleware/notificationsMiddleware.ts
+++ b/src/logic/safe/store/middleware/notificationsMiddleware.ts
@@ -118,7 +118,7 @@ const notificationsMiddleware =
             shortName: currentShortName,
             safeAddress,
           }),
-          title: 'Transaction Queue',
+          title: 'View Transaction Queue',
         }
 
         sendAwaitingTransactionNotification(dispatch, safeAddress, awaitingTxsSubmissionDateList, link)

--- a/src/logic/safe/transactions/pendingTxMonitor.ts
+++ b/src/logic/safe/transactions/pendingTxMonitor.ts
@@ -71,7 +71,7 @@ const monitorTx = async ({
       })
 
       store.dispatch(
-        showNotification({ ...NOTIFICATIONS.TX_PENDING_FAILED_MSG, link: { to: deeplink, title: 'Transaction' } }),
+        showNotification({ ...NOTIFICATIONS.TX_PENDING_FAILED_MSG, link: { to: deeplink, title: 'View Transaction' } }),
       )
     })
 }

--- a/src/logic/safe/utils/aboutToExecuteTx.ts
+++ b/src/logic/safe/utils/aboutToExecuteTx.ts
@@ -52,7 +52,7 @@ export const getNotification = (
         [TRANSACTION_ID_SLUG]: executedTx.id,
       })
 
-      return { ...notification, link: { title: 'Transaction', to } }
+      return { ...notification, link: { title: 'View Transaction', to } }
     }
   }
 }


### PR DESCRIPTION
## What it solves
Resolves non-uniform notification labels

## How this PR fixes it
All instances of the transaction notification `title`s have been set as "View Transaction" instead of "Transaction".

## How to test it
1. Open a Safe with a fully confirmed, awaiting transaction and observe the notification label as "View Transaction".
2. Execute a transaction with low gas then immediately cancel it with high gas. Refresh the page before the transaction executes and, after the pending water finished (6.5 minutes), observe the pending failure notification label as "View Transaction".
3. Create and execute a transaction. Observe the notification label as "View Transaction".