### PR TITLE
Feature: include blockExplorerUriTemplate in Safe Apps getChainInfo response

### DIFF
--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -90,7 +90,7 @@ const APP_LOAD_ERROR = 'There was an error loading the Safe App. There might be 
 
 const AppFrame = ({ appUrl }: Props): ReactElement => {
   const { address: safeAddress, ethBalance, owners, threshold } = useSelector(currentSafe)
-  const { nativeCurrency, chainId, chainName, shortName } = getChainInfo()
+  const { nativeCurrency, chainId, chainName, shortName, blockExplorerUriTemplate } = getChainInfo()
   const safeName = useSelector((state) => addressBookEntryName(state, { address: safeAddress }))
   const granted = useSelector(grantedSelector)
   const iframeRef = useRef<HTMLIFrameElement>(null)
@@ -275,6 +275,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
         chainId,
         shortName,
         nativeCurrency,
+        blockExplorerUriTemplate,
       }
     })
   }, [
@@ -290,6 +291,7 @@ const AppFrame = ({ appUrl }: Props): ReactElement => {
     shortName,
     safeAppWeb3Provider,
     granted,
+    blockExplorerUriTemplate,
   ])
 
   const onUserTxConfirm = (safeTxHash: string, requestId: RequestId) => {


### PR DESCRIPTION
## What it solves
This is needed for https://github.com/safe-global/safe-react-apps/issues/456 because we want to have a link to the implementation contract on a block explorer 

## How this PR fixes it
By including the `blockExplorerUriTemplate` in the response for an existing `getChainInfo` call

## How to test it
Call `getChainInfo` with an SDK and check if it's included in the response
