### PR TITLE
Feat: migrate local data via postMessage

### DIFF
--- a/public/migrate.html
+++ b/public/migrate.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script>
+  ;(function () {
+    const allowedOrigins = [
+      'http://localhost:3000',
+      'https://migrate.web-core.pages.dev',
+      'https://web-core.pages.dev',
+      'https://beta.safe.global',
+      'https://app.safe.global',
+    ]
+    // Send the entire localStorage if the origin is allowed
+    window.addEventListener('message', function (event) {
+      if (allowedOrigins.includes(event.origin)) {
+        event.source.postMessage(
+          {
+            type: 'migration-data',
+            payload: JSON.parse(JSON.stringify(localStorage)),
+          },
+          event.origin
+        )
+      }
+    })
+  })()
+</script>


### PR DESCRIPTION
This PR adds a new HTML file that helps perform the migration of locally stored data to another domain.

* Listens to postMessage events
* Check that the event comes from an allowed host
* Sends the entire localStorage back to that window