### PR TITLE
tests: use the RPC uri returned by the services in E2E

### DIFF
--- a/src/logic/wallets/e2e-wallet/module.ts
+++ b/src/logic/wallets/e2e-wallet/module.ts
@@ -1,6 +1,6 @@
 import HDWalletProvider from '@truffle/hdwallet-provider'
 import { WalletModule } from 'bnc-onboard/dist/src/interfaces'
-import { getPublicRpcUrl } from 'src/config'
+import { getRpcServiceUrl } from 'src/config'
 import CypressLogo from 'src/assets/icons/cypress_logo.svg'
 
 const WALLET_NAME = 'E2E Wallet'
@@ -14,7 +14,7 @@ const getE2EWalletModule = (): WalletModule => {
       const { createModernProviderInterface } = helpers
       const provider = new HDWalletProvider({
         mnemonic: window.Cypress.env('CYPRESS_MNEMONIC'),
-        providerOrUrl: getPublicRpcUrl(),
+        providerOrUrl: getRpcServiceUrl(),
       })
       return {
         provider,


### PR DESCRIPTION
## What it solves
Resolves E2E tests failing due to a timeout in the gas estimation.

## How this PR fixes it
Uses the `rpcUri` returned in the config instead of the public `publicRpcUri` for a reliable estimation

## How to test it
Run  `add_owner.spec` and `tx_modal.spec` locally against this branch and both tests should past the gas estimation assertion

```
// Estimated gas price is loaded
cy.contains('Estimated fee price').next().should('not.have.text', '> 0.001 ETH')
