### PR TITLE
fix: Verify spending limit contract address for displaying custom UI

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/SpendingLimitDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/SpendingLimitDetails.tsx
@@ -9,6 +9,9 @@ import { AddressInfo, ResetTimeInfo, TokenInfo } from 'src/routes/safe/component
 import { TransactionData, TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getTxTo } from 'src/routes/safe/components/Transactions/TxList/utils'
 import { StyledDetailsTitle, StyledTxInfoDetails } from 'src/routes/safe/components/Transactions/TxList/styled'
+import { isCustomTxInfo } from 'src/logic/safe/store/models/types/gateway'
+import { getSpendingLimitModuleAddress } from 'src/logic/contracts/spendingLimitContracts'
+import { _getChainId } from 'src/config'
 
 const SET_ALLOWANCE = 'setAllowance'
 const DELETE_ALLOWANCE = 'deleteAllowance'
@@ -23,6 +26,13 @@ export const isDeleteAllowance = (method?: string): boolean => {
 
 export const isSpendingLimitMethod = (method?: string): boolean => {
   return isSetAllowance(method) || isDeleteAllowance(method)
+}
+
+export const isSpendingLimitTx = (txInfo: TransactionInfo): boolean => {
+  const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''
+  const moduleAddress = getSpendingLimitModuleAddress(_getChainId())
+
+  return sameString(moduleAddress, toAddress)
 }
 
 const StyledInfoBlock = styled.div`

--- a/src/routes/safe/components/Transactions/TxList/SpendingLimitDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/SpendingLimitDetails.tsx
@@ -9,7 +9,7 @@ import { AddressInfo, ResetTimeInfo, TokenInfo } from 'src/routes/safe/component
 import { TransactionData, TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getTxTo } from 'src/routes/safe/components/Transactions/TxList/utils'
 import { StyledDetailsTitle, StyledTxInfoDetails } from 'src/routes/safe/components/Transactions/TxList/styled'
-import { isCustomTxInfo } from 'src/logic/safe/store/models/types/gateway'
+import { isCustomTxInfo } from 'src/logic/safe/store/models/types/gateway.d'
 import { getSpendingLimitModuleAddress } from 'src/logic/contracts/spendingLimitContracts'
 import { _getChainId } from 'src/config'
 
@@ -28,11 +28,11 @@ export const isSpendingLimitMethod = (method?: string): boolean => {
   return isSetAllowance(method) || isDeleteAllowance(method)
 }
 
-export const isSpendingLimitTx = (txInfo: TransactionInfo): boolean => {
+export const isSupportedSpendingLimitAddress = (txInfo: TransactionInfo): boolean => {
   const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''
-  const moduleAddress = getSpendingLimitModuleAddress(_getChainId())
+  const spendingLimitModuleAddress = getSpendingLimitModuleAddress(_getChainId())
 
-  return sameString(moduleAddress, toAddress)
+  return sameString(spendingLimitModuleAddress, toAddress)
 }
 
 const StyledInfoBlock = styled.div`

--- a/src/routes/safe/components/Transactions/TxList/TxData.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxData.tsx
@@ -8,7 +8,7 @@ import {
   DeleteSpendingLimitDetails,
   isDeleteAllowance,
   isSetAllowance,
-  isSpendingLimitTx,
+  isSupportedSpendingLimitAddress,
   ModifySpendingLimitDetails,
 } from './SpendingLimitDetails'
 import { TxInfoDetails } from './TxInfoDetails'
@@ -76,12 +76,12 @@ export const TxData = ({ txData, txInfo }: TxDataProps): ReactElement | null => 
   }
 
   // FixMe: this way won't scale well
-  if (isSpendingLimitTx(txInfo) && isSetAllowance(txData.dataDecoded.method)) {
+  if (isSupportedSpendingLimitAddress(txInfo) && isSetAllowance(txData.dataDecoded.method)) {
     return <ModifySpendingLimitDetails txData={txData} txInfo={txInfo} />
   }
 
   // FixMe: this way won't scale well
-  if (isSpendingLimitTx(txInfo) && isDeleteAllowance(txData.dataDecoded.method)) {
+  if (isSupportedSpendingLimitAddress(txInfo) && isDeleteAllowance(txData.dataDecoded.method)) {
     return <DeleteSpendingLimitDetails txData={txData} txInfo={txInfo} />
   }
 

--- a/src/routes/safe/components/Transactions/TxList/TxData.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxData.tsx
@@ -8,6 +8,7 @@ import {
   DeleteSpendingLimitDetails,
   isDeleteAllowance,
   isSetAllowance,
+  isSpendingLimitTx,
   ModifySpendingLimitDetails,
 } from './SpendingLimitDetails'
 import { TxInfoDetails } from './TxInfoDetails'
@@ -75,12 +76,12 @@ export const TxData = ({ txData, txInfo }: TxDataProps): ReactElement | null => 
   }
 
   // FixMe: this way won't scale well
-  if (isSetAllowance(txData.dataDecoded.method)) {
+  if (isSpendingLimitTx(txInfo) && isSetAllowance(txData.dataDecoded.method)) {
     return <ModifySpendingLimitDetails txData={txData} txInfo={txInfo} />
   }
 
   // FixMe: this way won't scale well
-  if (isDeleteAllowance(txData.dataDecoded.method)) {
+  if (isSpendingLimitTx(txInfo) && isDeleteAllowance(txData.dataDecoded.method)) {
     return <DeleteSpendingLimitDetails txData={txData} txInfo={txInfo} />
   }
 


### PR DESCRIPTION
## What it solves
The app is crashing in https://gnosis-safe.io/app/eth:0x63Ef071b8A69C52a88dCA4A844286Aeff195129F/transactions/history when expanding a "Contract interaction - setAllowance".
Resolves #4021

## How this PR fixes it
What is happening, in reality, is that the web app is rendering a SpendingLimit transaction details whenever there is a Contract interaction calling any `setAllowance` or `deleteAllowance`.

In the reported Safe, the crashing transactions are made to a different contract than our AllowanceModule and we are wrongly trying to display the SpendingLimit custom TxDetails for a method that can be called with totally different parameters.

The fix verifies taht the `setAllowance` and `deleteAllowance` calls are made to our AllowanceModule known addresses -> https://github.com/safe-global/safe-modules/blob/master/allowances/networks.json

## How to test it

1. Open the safe `eth:0x63Ef071b8A69C52a88dCA4A844286Aeff195129F`
2. Go to Transaction history
3. Expand a "Contract interaction - setAllowance" transaction details
4. Observe the app renders the transaction data nicely without assuming it is a SpendingLimit tx

