### PR TITLE
fix: verify multisend contract address

### DIFF
--- a/src/logic/safe/store/models/types/__tests__/gateway.d.test.ts
+++ b/src/logic/safe/store/models/types/__tests__/gateway.d.test.ts
@@ -7,7 +7,6 @@ import {
   isTransferTxInfo,
   isSettingsChangeTxInfo,
   isCustomTxInfo,
-  isMultiSendTxInfo,
   isCreationTxInfo,
   isMultiSigExecutionDetails,
   isModuleExecutionInfo,
@@ -140,43 +139,6 @@ describe('isCustomTxInfo', () => {
 
     // @ts-ignore - Sending an invalid object
     expect(isCustomTxInfo(data)).toBe(false)
-  })
-})
-describe('isMultiSendTxInfo', () => {
-  it('returns true when it is a custom multisend transaction', () => {
-    const data = {
-      type: 'Custom',
-      methodName: 'multiSend',
-    }
-
-    // @ts-ignore - Sending an invalid object
-    expect(isMultiSendTxInfo(data)).toBe(true)
-  })
-  it('returns false when it is not a custom multisend transaction', () => {
-    const data = {
-      type: 'TEST',
-      methodName: 'multiSend',
-    }
-
-    // @ts-ignore - Sending an invalid object
-    expect(isMultiSendTxInfo(data)).toBe(false)
-  })
-  it('returns false when it is just a multisend transaction', () => {
-    const data = {
-      methodName: 'multiSend',
-    }
-
-    // @ts-ignore - Sending an invalid object
-    expect(isMultiSendTxInfo(data)).toBe(false)
-  })
-  it('returns false when it is not a custom multisend transaction', () => {
-    const data = {
-      type: 'TEST',
-      methodName: 'multiSend',
-    }
-
-    // @ts-ignore - Sending an invalid object
-    expect(isMultiSendTxInfo(data)).toBe(false)
   })
 })
 

--- a/src/logic/safe/store/models/types/gateway.d.ts
+++ b/src/logic/safe/store/models/types/gateway.d.ts
@@ -4,7 +4,6 @@ import {
   DateLabel,
   Label,
   ModuleExecutionDetails,
-  MultiSend,
   MultisigExecutionDetails,
   MultisigExecutionInfo,
   TransactionSummary,
@@ -95,10 +94,6 @@ export const isSettingsChangeTxInfo = (value: TransactionInfo): value is Setting
 
 export const isCustomTxInfo = (value: TransactionInfo): value is Custom => {
   return value.type === 'Custom'
-}
-
-export const isMultiSendTxInfo = (value: TransactionInfo): value is MultiSend => {
-  return isCustomTxInfo(value) && value.methodName === 'multiSend'
 }
 
 export const isCreationTxInfo = (value: TransactionInfo): value is Creation => {

--- a/src/logic/safe/transactions/__tests__/multisend.test.ts
+++ b/src/logic/safe/transactions/__tests__/multisend.test.ts
@@ -1,0 +1,46 @@
+import { TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+import { isSupportedMultiSendCall } from 'src/logic/safe/transactions/multisend'
+
+const MULTISEND_ADDRESS = '0x40a2accbd92bca938b02010e17a5b8929b49130d'
+jest.mock('src/logic/contracts/safeContracts', () => ({
+  ...jest.requireActual('src/logic/contracts/safeContracts'),
+  getMultisendContractAddress: () => MULTISEND_ADDRESS,
+}))
+
+describe('isSupportedMultiSendCall', () => {
+  it('should return true if multiSend call is made to supported Multisend contract', () => {
+    const data = {
+      type: 'Custom',
+      methodName: 'multiSend',
+      to: {
+        value: '0x40a2accbd92bca938b02010e17a5b8929b49130d',
+      },
+    } as TransactionInfo
+
+    expect(isSupportedMultiSendCall(data)).toBe(true)
+  })
+
+  it('should fail if Multisend contract is not the supported one', () => {
+    const data = {
+      type: 'Custom',
+      methodName: 'multiSend',
+      to: {
+        value: '0x0000000000000000000000000000000000000000',
+      },
+    } as TransactionInfo
+
+    expect(isSupportedMultiSendCall(data)).toBe(false)
+  })
+
+  it('should fail if txInfo methodName is not "multiSend"', () => {
+    const data = {
+      type: 'Custom',
+      methodName: 'foobar',
+      to: {
+        value: '0x40a2accbd92bca938b02010e17a5b8929b49130d',
+      },
+    } as TransactionInfo
+
+    expect(isSupportedMultiSendCall(data)).toBe(false)
+  })
+})

--- a/src/logic/safe/transactions/multisend.ts
+++ b/src/logic/safe/transactions/multisend.ts
@@ -2,7 +2,7 @@ import { Transaction } from '@gnosis.pm/safe-apps-sdk-v1'
 
 import { getWeb3 } from 'src/logic/wallets/getWeb3'
 import { getMultisendContract, getMultisendContractAddress } from 'src/logic/contracts/safeContracts'
-import { TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+import { MultiSend, TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { isCustomTxInfo } from 'src/logic/safe/store/models/types/gateway.d'
 import { sameString } from 'src/utils/strings'
 
@@ -44,3 +44,6 @@ export const isSupportedMultiSendAddress = (txInfo: TransactionInfo): boolean =>
 
   return sameString(multiSendAddress, toAddress)
 }
+
+export const isSupportedMultiSendCall = (txInfo: TransactionInfo): txInfo is MultiSend =>
+  isSupportedMultiSendAddress(txInfo) && isCustomTxInfo(txInfo) && txInfo.methodName === 'multiSend'

--- a/src/logic/safe/transactions/multisend.ts
+++ b/src/logic/safe/transactions/multisend.ts
@@ -1,7 +1,10 @@
 import { Transaction } from '@gnosis.pm/safe-apps-sdk-v1'
 
 import { getWeb3 } from 'src/logic/wallets/getWeb3'
-import { getMultisendContract } from 'src/logic/contracts/safeContracts'
+import { getMultisendContract, getMultisendContractAddress } from 'src/logic/contracts/safeContracts'
+import { TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+import { isCustomTxInfo } from 'src/logic/safe/store/models/types/gateway.d'
+import { sameString } from 'src/utils/strings'
 
 export interface MultiSendTx {
   to: string
@@ -33,4 +36,11 @@ export const getMultiSendJoinedTxs = (txs: Transaction[]): string => {
     .join('')
 
   return `0x${joinedTxs}`
+}
+
+export const isSupportedMultiSendAddress = (txInfo: TransactionInfo): boolean => {
+  const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''
+  const multiSendAddress = getMultisendContractAddress()
+
+  return sameString(multiSendAddress, toAddress)
 }

--- a/src/routes/safe/components/Transactions/TxList/TxCollapsed.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxCollapsed.tsx
@@ -8,7 +8,6 @@ import { useSelector } from 'react-redux'
 import { CustomIconText } from 'src/components/CustomIconText'
 import {
   isCustomTxInfo,
-  isMultiSendTxInfo,
   isSettingsChangeTxInfo,
   LocalTransactionStatus,
   Transaction,
@@ -29,6 +28,7 @@ import { userAccountSelector } from 'src/logic/wallets/store/selectors'
 import { useKnownAddress } from './hooks/useKnownAddress'
 import useTxStatus from 'src/logic/hooks/useTxStatus'
 import Spacer from 'src/components/Spacer'
+import { isSupportedMultiSendCall } from 'src/logic/safe/transactions/multisend'
 
 export const TxInfo = ({ info, name }: { info: AssetInfo; name?: string }): ReactElement | null => {
   if (isTokenTransferAsset(info)) {
@@ -59,7 +59,7 @@ export const TxInfo = ({ info, name }: { info: AssetInfo; name?: string }): Reac
   }
 
   if (isCustomTxInfo(info)) {
-    if (isMultiSendTxInfo(info)) {
+    if (isSupportedMultiSendCall(info)) {
       return (
         <Text size="xl" as="span">
           {info.actionCount} {`action${(info as MultiSend).actionCount > 1 ? 's' : ''}`}

--- a/src/routes/safe/components/Transactions/TxList/TxData.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxData.tsx
@@ -2,7 +2,7 @@ import { TransactionData } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ReactElement, ReactNode } from 'react'
 
 import { getNativeCurrency } from 'src/config'
-import { ExpandedTxDetails, isCustomTxInfo, isMultiSendTxInfo } from 'src/logic/safe/store/models/types/gateway.d'
+import { ExpandedTxDetails, isCustomTxInfo } from 'src/logic/safe/store/models/types/gateway.d'
 import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'
 import {
   DeleteSpendingLimitDetails,
@@ -16,7 +16,7 @@ import { MethodDetails } from './MethodDetails'
 import { MultiSendDetails } from './MultiSendDetails'
 import { TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getInteractionTitle } from '../helpers/utils'
-import { isSupportedMultiSendAddress } from 'src/logic/safe/transactions/multisend'
+import { isSupportedMultiSendCall } from 'src/logic/safe/transactions/multisend'
 
 type DetailsWithTxInfoProps = {
   children: ReactNode
@@ -69,8 +69,7 @@ export const TxData = ({ txData, txInfo }: TxDataProps): ReactElement | null => 
     )
   }
 
-  // known MultiSend contract address and methodName 'multiSend'
-  if (isSupportedMultiSendAddress(txInfo) && isMultiSendTxInfo(txInfo)) {
+  if (isSupportedMultiSendCall(txInfo)) {
     return <MultiSendDetails txData={txData} />
   }
 

--- a/src/routes/safe/components/Transactions/TxList/TxData.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxData.tsx
@@ -2,7 +2,7 @@ import { TransactionData } from '@gnosis.pm/safe-react-gateway-sdk'
 import { ReactElement, ReactNode } from 'react'
 
 import { getNativeCurrency } from 'src/config'
-import { ExpandedTxDetails, isCustomTxInfo } from 'src/logic/safe/store/models/types/gateway.d'
+import { ExpandedTxDetails, isCustomTxInfo, isMultiSendTxInfo } from 'src/logic/safe/store/models/types/gateway.d'
 import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'
 import {
   DeleteSpendingLimitDetails,
@@ -11,12 +11,12 @@ import {
   ModifySpendingLimitDetails,
 } from './SpendingLimitDetails'
 import { TxInfoDetails } from './TxInfoDetails'
-import { sameString } from 'src/utils/strings'
 import { HexEncodedData } from './HexEncodedData'
 import { MethodDetails } from './MethodDetails'
 import { MultiSendDetails } from './MultiSendDetails'
 import { TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { getInteractionTitle } from '../helpers/utils'
+import { isSupportedMultiSendAddress } from 'src/logic/safe/transactions/multisend'
 
 type DetailsWithTxInfoProps = {
   children: ReactNode
@@ -69,8 +69,8 @@ export const TxData = ({ txData, txInfo }: TxDataProps): ReactElement | null => 
     )
   }
 
-  // known data and particularly `multiSend` data type
-  if (sameString(txData.dataDecoded.method, 'multiSend')) {
+  // known MultiSend contract address and methodName 'multiSend'
+  if (isSupportedMultiSendAddress(txInfo) && isMultiSendTxInfo(txInfo)) {
     return <MultiSendDetails txData={txData} />
   }
 

--- a/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxDetails.tsx
@@ -7,7 +7,6 @@ import {
   ExpandedTxDetails,
   isCustomTxInfo,
   isModuleExecutionInfo,
-  isMultiSendTxInfo,
   isMultiSigExecutionDetails,
   isSettingsChangeTxInfo,
   isTransferTxInfo,
@@ -30,6 +29,7 @@ import TxModuleInfo from './TxModuleInfo'
 import Track from 'src/components/Track'
 import { TX_LIST_EVENTS } from 'src/utils/events/txList'
 import TxShareButton from './TxShareButton'
+import { isSupportedMultiSendCall } from 'src/logic/safe/transactions/multisend'
 
 const NormalBreakingText = styled(Text)`
   line-break: normal;
@@ -98,7 +98,7 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
   const willBeReplaced = txStatus === LocalTransactionStatus.WILL_BE_REPLACED
   const isPending = txStatus === LocalTransactionStatus.PENDING
   const currentUser = useSelector(userAccountSelector)
-  const isMultiSend = data && isMultiSendTxInfo(data.txInfo)
+  const isMultiSend = data && isSupportedMultiSendCall(data.txInfo)
   const shouldShowStepper = data?.detailedExecutionInfo && isMultiSigExecutionDetails(data.detailedExecutionInfo)
 
   // To avoid prop drilling into TxDataGroup, module details are positioned here accordingly
@@ -154,8 +154,7 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
         </div>
         {getModuleDetails()}
         <div
-          className={cn('tx-details', {
-            'no-padding': isMultiSendTxInfo(data.txInfo),
+          className={cn('tx-details', 'no-padding', {
             'not-executed': !data.executedAt,
             'will-be-replaced': willBeReplaced,
           })}
@@ -167,7 +166,7 @@ export const TxDetails = ({ transaction }: TxDetailsProps): ReactElement => {
       <>
         <div
           className={cn('tx-details', {
-            'no-padding': isMultiSendTxInfo(data.txInfo) || noTxDataBlock,
+            'no-padding': noTxDataBlock,
             'not-executed': !data.executedAt,
             'will-be-replaced': willBeReplaced,
           })}

--- a/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
+++ b/src/routes/safe/components/Transactions/TxList/TxSummary.tsx
@@ -4,16 +4,13 @@ import { ButtonLink } from '@gnosis.pm/safe-react-components'
 import styled from 'styled-components'
 
 import { formatDateTime } from 'src/utils/date'
-import {
-  ExpandedTxDetails,
-  isMultiSendTxInfo,
-  isMultiSigExecutionDetails,
-} from 'src/logic/safe/store/models/types/gateway.d'
+import { ExpandedTxDetails, isMultiSigExecutionDetails } from 'src/logic/safe/store/models/types/gateway.d'
 import { NOT_AVAILABLE } from './utils'
 import TxInfoMultiSend from './TxInfoMultiSend'
 import DelegateCallWarning from './DelegateCallWarning'
 import { TxDataRow } from 'src/routes/safe/components/Transactions/TxList/TxDataRow'
 import { sm } from 'src/theme/variables'
+import { isSupportedMultiSendCall } from 'src/logic/safe/transactions/multisend'
 
 const StyledButtonLink = styled(ButtonLink)`
   margin-top: ${sm};
@@ -62,7 +59,7 @@ export const TxSummary = ({ txDetails }: Props): ReactElement => {
           <DelegateCallWarning showWarning={!txData.trustedDelegateCallTarget} />
         </div>
       )}
-      {isMultiSendTxInfo(txInfo) && (
+      {isSupportedMultiSendCall(txInfo) && (
         <>
           <TxInfoMultiSend txInfo={txInfo} />
           <br />


### PR DESCRIPTION
## What it solves
Related to #4021 as a Custom contract interaction calling a `multiSend` method could break the UI

## How this PR fixes it
The type guard to verify if a transaction is a supported `multisend` call verifies the called contract address

## How to test it
Having a transaction interacting with a `multiSend` method in a different contract than the supported Multisend should not display a custom TxDetails UI

1. Transaction with an [unsupported "multiSend" contract](https://gnosis-safe.io/app/rin:0x7a9af6Ef9197041A5841e84cB27873bEBd3486E2/transactions/multisig_0x7a9af6Ef9197041A5841e84cB27873bEBd3486E2_0xe0804fca410add0a1ac138d2ecbf64f58fa0b9a9630287e8c0ab425c26761a34)
