### PR TITLE
style: Fix tree lines for grouped txs

### DIFF
--- a/src/routes/safe/components/Transactions/TxList/styled.tsx
+++ b/src/routes/safe/components/Transactions/TxList/styled.tsx
@@ -240,8 +240,8 @@ export const GroupedTransactions = styled(StyledTransaction)`
 
   // builds the tree-view layout
   .tree-lines {
-    height: 100%;
-    margin-left: 30px;
+    height: auto;
+    margin: 0 0 0 30px;
     position: relative;
     width: 30%;
 
@@ -259,7 +259,7 @@ export const GroupedTransactions = styled(StyledTransaction)`
         content: '';
         height: 22px;
         position: absolute;
-        top: 8px;
+        top: 18px;
         width: 100%;
       }
     }
@@ -274,7 +274,7 @@ export const GroupedTransactions = styled(StyledTransaction)`
         border-left: 2px solid ${({ theme }) => theme.colors.separator};
         content: '';
         height: 100%;
-        margin-top: 14px;
+        margin-top: 26px;
         position: absolute;
         width: 100%;
       }


### PR DESCRIPTION
Reported via [Slack](https://5afe.slack.com/archives/C03DAGWJCR5/p1658406862903569)

## How this PR fixes it

- Adjusts css for the vertical `tree-lines` in grouped txs to fix an issue in Safari

## How to test it

- Open a Safe with grouped transactions in the queue in Safari Browser
- Observe all transactions are visible

## Screenshots

<img width="1261" alt="Screenshot 2022-07-21 at 15 01 06" src="https://user-images.githubusercontent.com/5880855/180219699-27607e08-0ff4-482f-a9e0-060af36286b7.png">

