### PR TITLE
feat: add Exodus wallet support

### DIFF
--- a/src/config/chain.d.ts
+++ b/src/config/chain.d.ts
@@ -20,6 +20,7 @@ export enum WALLETS {
   SAFE_MOBILE = 'safeMobile',
   METAMASK = 'metamask',
   TALLYHO = 'tally',
+  EXODUS = 'exodus',
   WALLET_CONNECT = 'walletConnect',
   TREZOR = 'trezor',
   LEDGER = 'ledger',

--- a/src/logic/wallets/utils/walletList.ts
+++ b/src/logic/wallets/utils/walletList.ts
@@ -20,6 +20,7 @@ const wallets = (chainId: ChainId): Wallet[] => {
 
   return [
     { walletName: WALLETS.METAMASK, preferred: true, desktop: false },
+    { walletName: WALLETS.EXODUS, preferred: true, desktop: true },
     { walletName: WALLETS.TALLYHO, preferred: false, desktop: false },
     {
       walletName: WALLETS.WALLET_CONNECT,


### PR DESCRIPTION
## Summary
Integrate Exodus wallet provider support

## How to test it
1. Install [Exodus Browser Extension](https://www.exodus.com/browser-extension/)
2. Click "Connect Wallet"
3. Select Exodus
4. It should connect successfully

## Screenshots
<img width="638" alt="image" src="https://user-images.githubusercontent.com/38049232/182253333-83b87073-2036-4030-9f5d-67c2edffa915.png">
