### PR TITLE
fix: Extend isSupportedMultiSendAddress

### DIFF
--- a/src/components/TransactionQueueBar/TransactionQueueBar.test.tsx
+++ b/src/components/TransactionQueueBar/TransactionQueueBar.test.tsx
@@ -7,7 +7,7 @@ import { generateSafeRoute, history, SAFE_ROUTES } from 'src/routes/routes'
 const MULTISEND_ADDRESS = '0x4242424242424242424242424242424242424242'
 jest.mock('src/logic/contracts/safeContracts', () => ({
   ...jest.requireActual('src/logic/contracts/safeContracts'),
-  getMultisendContractAddress: () => MULTISEND_ADDRESS,
+  getMultiSendCallOnlyContractAddress: () => MULTISEND_ADDRESS,
 }))
 
 const safeAddress = '0x57CB13cbef735FbDD65f5f2866638c546464E45F'

--- a/src/logic/safe/store/actions/TxMultiSender.ts
+++ b/src/logic/safe/store/actions/TxMultiSender.ts
@@ -3,7 +3,7 @@ import { isMultisigExecutionInfo, Transaction } from 'src/logic/safe/store/model
 import { MultiSend } from 'src/types/contracts/multi_send.d'
 import { addPendingTransaction, removePendingTransaction } from 'src/logic/safe/store/actions/pendingTransactions'
 import { Errors, logError } from 'src/logic/exceptions/CodedException'
-import { getMultisendContract } from 'src/logic/contracts/safeContracts'
+import { getMultiSendCallOnlyContract } from 'src/logic/contracts/safeContracts'
 import { createTxNotifications } from 'src/logic/notifications'
 import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
 import * as aboutToExecuteTx from 'src/logic/safe/utils/aboutToExecuteTx'
@@ -31,7 +31,7 @@ export class TxMultiSender {
   constructor({ transactions, multiSendCallData, dispatch, account, safeAddress }: TxMultiSenderProps) {
     this.transactions = transactions
     this.multiSendCallData = multiSendCallData
-    this.multiSendContract = getMultisendContract()
+    this.multiSendContract = getMultiSendCallOnlyContract()
     this.dispatch = dispatch
     this.account = account
     this.notifications = createTxNotifications(dispatch, TX_NOTIFICATION_TYPES.STANDARD_TX)

--- a/src/logic/safe/transactions/__tests__/multisend.test.ts
+++ b/src/logic/safe/transactions/__tests__/multisend.test.ts
@@ -4,7 +4,8 @@ import { isSupportedMultiSendCall } from 'src/logic/safe/transactions/multisend'
 const MULTISEND_ADDRESS = '0x40a2accbd92bca938b02010e17a5b8929b49130d'
 jest.mock('src/logic/contracts/safeContracts', () => ({
   ...jest.requireActual('src/logic/contracts/safeContracts'),
-  getMultisendContractAddress: () => MULTISEND_ADDRESS,
+  getMultiSendCallOnlyContractAddress: () => MULTISEND_ADDRESS,
+  getMultiSendContractAddress: () => MULTISEND_ADDRESS,
 }))
 
 describe('isSupportedMultiSendCall', () => {

--- a/src/logic/safe/transactions/multisend.ts
+++ b/src/logic/safe/transactions/multisend.ts
@@ -1,7 +1,11 @@
 import { Transaction } from '@gnosis.pm/safe-apps-sdk-v1'
 
 import { getWeb3 } from 'src/logic/wallets/getWeb3'
-import { getMultisendContract, getMultisendContractAddress } from 'src/logic/contracts/safeContracts'
+import {
+  getMultiSendCallOnlyContract,
+  getMultiSendCallOnlyContractAddress,
+  getMultiSendContractAddress,
+} from 'src/logic/contracts/safeContracts'
 import { MultiSend, TransactionInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { isCustomTxInfo } from 'src/logic/safe/store/models/types/gateway.d'
 import { sameString } from 'src/utils/strings'
@@ -13,7 +17,7 @@ export interface MultiSendTx {
 }
 
 export const encodeMultiSendCall = (txs: Transaction[]): string => {
-  const multiSend = getMultisendContract()
+  const multiSend = getMultiSendCallOnlyContract()
   const joinedTxs = getMultiSendJoinedTxs(txs)
 
   return multiSend.methods.multiSend(joinedTxs).encodeABI()
@@ -40,9 +44,10 @@ export const getMultiSendJoinedTxs = (txs: Transaction[]): string => {
 
 export const isSupportedMultiSendAddress = (txInfo: TransactionInfo): boolean => {
   const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''
-  const multiSendAddress = getMultisendContractAddress()
+  const multiSendCallOnlyAddress = getMultiSendCallOnlyContractAddress()
+  const multiSendAddress = getMultiSendContractAddress()
 
-  return sameString(multiSendAddress, toAddress)
+  return sameString(multiSendAddress, toAddress) || sameString(multiSendCallOnlyAddress, toAddress)
 }
 
 export const isSupportedMultiSendCall = (txInfo: TransactionInfo): txInfo is MultiSend =>

--- a/src/logic/safe/utils/__tests__/upgradeSafe.test.ts
+++ b/src/logic/safe/utils/__tests__/upgradeSafe.test.ts
@@ -11,7 +11,7 @@ const SAFE_MASTER_COPY_ADDRESS = '0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F'
 const DEFAULT_FALLBACK_HANDLER_ADDRESS = '0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44'
 
 jest.mock('src/logic/contracts/safeContracts', () => ({
-  getMultisendContract: jest.fn(),
+  getMultiSendCallOnlyContract: jest.fn(),
 }))
 
 describe('Upgrade a < 1.3.0 Safe', () => {
@@ -23,7 +23,7 @@ describe('Upgrade a < 1.3.0 Safe', () => {
 
     // Mock multisend contract instance
     const multiSendCallOnlyDeployment = getMultiSendCallOnlyDeployment()
-    safeContracts.getMultisendContract.mockReturnValue(
+    safeContracts.getMultiSendCallOnlyContract.mockReturnValue(
       new web3.eth.Contract(multiSendCallOnlyDeployment?.abi as AbiItem[]) as unknown as MultiSend,
     )
 

--- a/src/logic/safe/utils/spendingLimits.ts
+++ b/src/logic/safe/utils/spendingLimits.ts
@@ -6,7 +6,7 @@ import { CreateTransactionArgs } from 'src/logic/safe/store/actions/createTransa
 import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
 import { enableModuleTx, isModuleEnabled } from 'src/logic/safe/utils/modules'
 import generateBatchRequests from 'src/logic/contracts/generateBatchRequests'
-import { getMultisendContractAddress } from 'src/logic/contracts/safeContracts'
+import { getMultiSendCallOnlyContractAddress } from 'src/logic/contracts/safeContracts'
 import { SpendingLimit } from 'src/logic/safe/store/models/safe'
 import { sameAddress, ZERO_ADDRESS } from 'src/logic/wallets/ethAddresses'
 import { getWeb3ReadOnly } from 'src/logic/wallets/getWeb3'
@@ -258,7 +258,7 @@ export const spendingLimitMultiSendTx = ({
   safeAddress,
 }: SpendingLimitMultiSendTx): CreateTransactionArgs => ({
   safeAddress,
-  to: getMultisendContractAddress(),
+  to: getMultiSendCallOnlyContractAddress(),
   valueInWei: ZERO_VALUE,
   txData: encodeMultiSendCall(transactions),
   notifiedTransaction: TX_NOTIFICATION_TYPES.NEW_SPENDING_LIMIT_TX,

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ConfirmTxModal.test.tsx
@@ -8,8 +8,8 @@ import * as estimateTxGas from 'src/logic/hooks/useEstimateTransactionGas'
 const MULTISEND_ADDRESS = '0x4242424242424242424242424242424242424242'
 jest.mock('src/logic/contracts/safeContracts', () => ({
   ...jest.requireActual('src/logic/contracts/safeContracts'),
-  getMultisendContractAddress: () => MULTISEND_ADDRESS,
-  getMultisendContract: () => ({
+  getMultiSendCallOnlyContractAddress: () => MULTISEND_ADDRESS,
+  getMultiSendCallOnlyContract: () => ({
     methods: {
       multiSend: () => ({
         encodeABI: () => '0x',

--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { toBN } from 'web3-utils'
 
 import { createTransaction } from 'src/logic/safe/store/actions/createTransaction'
-import { getMultisendContractAddress } from 'src/logic/contracts/safeContracts'
+import { getMultiSendCallOnlyContractAddress } from 'src/logic/contracts/safeContracts'
 import { TX_NOTIFICATION_TYPES } from 'src/logic/safe/transactions'
 import { encodeMultiSendCall } from 'src/logic/safe/transactions/multisend'
 import { getExplorerInfo, getNativeCurrency } from 'src/config'
@@ -79,7 +79,7 @@ export const ReviewConfirm = ({
   const isOwner = useSelector(grantedSelector)
 
   const txRecipient: string | undefined = useMemo(
-    () => (isMultiSend ? getMultisendContractAddress() : txs[0]?.to),
+    () => (isMultiSend ? getMultiSendCallOnlyContractAddress() : txs[0]?.to),
     [txs, isMultiSend],
   )
   const txData: string | undefined = useMemo(

--- a/src/routes/safe/components/Settings/Advanced/Advanced.test.tsx
+++ b/src/routes/safe/components/Settings/Advanced/Advanced.test.tsx
@@ -33,7 +33,7 @@ jest.mock('src/logic/hooks/useEstimateTransactionGas', () => {
 
 describe('Advanced Settings Component', () => {
   beforeEach(() => {
-    jest.spyOn(safeContracts, 'getMultisendContractAddress').mockReturnValue('mockAddress')
+    jest.spyOn(safeContracts, 'getMultiSendCallOnlyContractAddress').mockReturnValue('mockAddress')
   })
   it('Renders Advanced Settings Component', () => {
     const customState = {

--- a/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
+++ b/src/routes/safe/components/Settings/UpdateSafeModal/index.tsx
@@ -9,7 +9,7 @@ import Paragraph from 'src/components/layout/Paragraph'
 import Row from 'src/components/layout/Row'
 import { getUpgradeSafeTransactionHash } from 'src/logic/safe/utils/upgradeSafe'
 import { createTransaction } from 'src/logic/safe/store/actions/createTransaction'
-import { getMultisendContractAddress } from 'src/logic/contracts/safeContracts'
+import { getMultiSendCallOnlyContractAddress } from 'src/logic/contracts/safeContracts'
 import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 import { TxParameters } from 'src/routes/safe/container/hooks/useTransactionParameters'
 import { ModalHeader } from 'src/routes/safe/components/Balances/SendModal/screens/ModalHeader'
@@ -39,7 +39,7 @@ export const UpdateSafeModal = ({ onClose, safeAddress, safeCurrentVersion }: Pr
     dispatch(
       createTransaction({
         safeAddress,
-        to: getMultisendContractAddress(),
+        to: getMultiSendCallOnlyContractAddress(),
         valueInWei: '0',
         txData: multiSendCallData,
         txNonce: txParameters.safeNonce,
@@ -56,7 +56,7 @@ export const UpdateSafeModal = ({ onClose, safeAddress, safeCurrentVersion }: Pr
   return (
     <TxModalWrapper
       txData={multiSendCallData}
-      txTo={getMultisendContractAddress()}
+      txTo={getMultiSendCallOnlyContractAddress()}
       operation={Operation.DELEGATE}
       onSubmit={handleSubmit}
       onClose={onClose}

--- a/src/routes/safe/components/Transactions/TxList/BatchExecute.tsx
+++ b/src/routes/safe/components/Transactions/TxList/BatchExecute.tsx
@@ -9,7 +9,7 @@ import { isCustomTxInfo, Transaction } from 'src/logic/safe/store/models/types/g
 import { fetchSafeTransaction } from 'src/logic/safe/transactions/api/fetchSafeTransaction'
 import { generateSignaturesFromTxConfirmations } from 'src/logic/safe/safeTxSigner'
 import { getExecutionTransaction } from 'src/logic/safe/transactions'
-import { getGnosisSafeInstanceAt, getMultisendContractAddress } from 'src/logic/contracts/safeContracts'
+import { getGnosisSafeInstanceAt, getMultiSendCallOnlyContractAddress } from 'src/logic/contracts/safeContracts'
 import { EMPTY_DATA } from 'src/logic/wallets/ethTransactions'
 import { encodeMultiSendCall, getMultiSendJoinedTxs, MultiSendTx } from 'src/logic/safe/transactions/multisend'
 import { userAccountSelector } from 'src/logic/wallets/store/selectors'
@@ -141,7 +141,7 @@ export const BatchExecute = React.memo((): ReactElement | null => {
   const dispatch = useDispatch<Dispatch>()
   const { address: safeAddress, currentVersion } = useSelector(currentSafe)
   const account = useSelector(userAccountSelector)
-  const multiSendContractAddress = getMultisendContractAddress()
+  const multiSendContractAddress = getMultiSendCallOnlyContractAddress()
   const batchableTransactions = useSelector(getBatchableTransactions)
   const [txsWithDetails, setTxsWithDetails] = useState<Transaction[]>([])
   const [isModalOpen, setModalOpen] = useState(false)
@@ -195,7 +195,7 @@ export const BatchExecute = React.memo((): ReactElement | null => {
     const txs = toMultiSendTxs(txsWithDetails, safeAddress, currentVersion, account)
     return {
       data: encodeMultiSendCall(txs),
-      to: getMultisendContractAddress(),
+      to: getMultiSendCallOnlyContractAddress(),
     }
   }, [account, txsWithDetails, currentVersion, safeAddress])
 


### PR DESCRIPTION
## What it solves
Related to #4021 

## How this PR fixes it

- Extends `isSupportedMultiSendAddress` to check both multiSend contracts

## How to test it

- Open `eth:0xEb3107117FEAd7de89Cd14D463D340A2E6917769/transactions/multisig_0xEb3107117FEAd7de89Cd14D463D340A2E6917769_0xea45c2dcec5f31f74eaf43f3c144e1eab772cbfeac077d816f89a70257212756`
- Observe the transaction being recognised as a multi send tx instead and displaying decoded data

## Screenshots

Before:
<img width="1262" alt="Screenshot 2022-08-03 at 17 36 01" src="https://user-images.githubusercontent.com/5880855/182649333-d80cc9d9-5760-49de-b720-ca2a37db9de3.png">

After:
<img width="1271" alt="Screenshot 2022-08-03 at 17 36 16" src="https://user-images.githubusercontent.com/5880855/182649390-a2680d01-b2de-44fc-a0a8-e4d69d03ff13.png">

