### PR TITLE
Add safeTxGas parameter on TxModal for Safe App tx

### DIFF
--- a/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
+++ b/src/routes/safe/components/Apps/components/ConfirmTxModal/ReviewConfirm.tsx
@@ -62,6 +62,7 @@ const parseTxValue = (value: string | number): string => {
 export const ReviewConfirm = ({
   app,
   txs,
+  params,
   safeAddress,
   ethBalance,
   safeName,
@@ -146,6 +147,7 @@ export const ReviewConfirm = ({
       onSubmit={confirmTransactions}
       isSubmitDisabled={!isOwner}
       onBack={onReject}
+      safeTxGas={params?.safeTxGas?.toString()}
     >
       <div>
         <ModalHeader title={app.name} iconUrl={app.iconUrl} onClose={onReject} />


### PR DESCRIPTION
## What it solves
Resolves #4036

## How this PR fixes it
Pass safeTxGas parameter to TxModalWrapper and parse from number to string if exists

## How to test it
[This Safe App](https://circles-groups-safe-jguyhds57-bootnode.vercel.app/) only available for Gnosis Chain, tries to set safeTxGas to 0. Parameter is currently ignored in prod.

After the change we set the suggested safeTxGas and we still calculate for those Safe Apps that don't suggest any value


More context directly in #4036 ticket