### PR TITLE
fix: don't COPY artifacts to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ WORKDIR /app
 
 COPY package.json yarn.lock .
 
-COPY  src/logic/contracts/artifacts ./src/logic/contracts/artifacts
-
 RUN yarn install
 
 COPY . .

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update \
 WORKDIR /app
 
 COPY package.json yarn.lock .
-COPY src/logic/contracts/artifacts ./src/logic/contracts/artifacts
 
 RUN yarn install
 


### PR DESCRIPTION
## What it solves
After commit 98476d07, there are no files to copy from `src/logic/contracts/artifacts` to the docker container, causing the build process to throw an error.

## How this PR fixes it
Remove COPY step, as it's no longer needed.

## How to test it
Via `docker-compose build`

