### PR TITLE
Fix: EIP712 signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@ethersproject/hash": "^5.6.1",
-    "@gnosis.pm/safe-apps-sdk": "7.7.0",
+    "@gnosis.pm/safe-apps-sdk": "https://gitpkg.now.sh/safe-global/safe-apps-sdk/packages/safe-apps-sdk?fix/eip712-signing",
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-core-sdk": "^2.0.0",
     "@gnosis.pm/safe-deployments": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@ethersproject/hash": "^5.6.1",
-    "@gnosis.pm/safe-apps-sdk": "https://gitpkg.now.sh/safe-global/safe-apps-sdk/packages/safe-apps-sdk?fix/eip712-signing",
+    "@gnosis.pm/safe-apps-sdk": "7.8.0",
     "@gnosis.pm/safe-apps-sdk-v1": "npm:@gnosis.pm/safe-apps-sdk@0.4.2",
     "@gnosis.pm/safe-core-sdk": "^2.0.0",
     "@gnosis.pm/safe-deployments": "^1.15.0",

--- a/src/routes/safe/components/Apps/components/AppFrame.tsx
+++ b/src/routes/safe/components/Apps/components/AppFrame.tsx
@@ -9,6 +9,7 @@ import {
   Methods,
   SignMessageParams,
   RequestId,
+  SignTypedMessageParams,
 } from '@gnosis.pm/safe-apps-sdk'
 import { useSelector } from 'react-redux'
 import { INTERFACE_MESSAGES, Transaction, LowercaseNetworks } from '@gnosis.pm/safe-apps-sdk-v1'
@@ -297,9 +298,9 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: Props): ReactElement => {
     })
 
     communicator?.on(Methods.signTypedMessage, async (msg) => {
-      const { message } = msg.data.params as SignMessageParams
+      const { typedData } = msg.data.params as SignTypedMessageParams
 
-      openSignMessageModal(message, msg.data.id, Methods.signTypedMessage)
+      openSignMessageModal(typedData, msg.data.id, Methods.signTypedMessage)
     })
 
     communicator?.on(Methods.getChainInfo, async () => {

--- a/src/routes/safe/components/Apps/components/SignMessageModal/SignMessageModal.test.tsx
+++ b/src/routes/safe/components/Apps/components/SignMessageModal/SignMessageModal.test.tsx
@@ -163,7 +163,7 @@ describe('SignMessageModal Component', () => {
       <SignMessageModal
         isOpen
         safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
-        message={JSON.stringify(typedMessage)}
+        message={typedMessage}
         safeName="test safe"
         ethBalance="100000000000000000"
         onClose={jest.fn()}
@@ -188,65 +188,15 @@ describe('SignMessageModal Component', () => {
     ).toBeVisible()
   })
 
-  test('If message is invalid JSON data, modal should be closed', () => {
-    const onCloseFn = jest.fn()
-    const typedMessageStr = `{
-        Person: [
-          { name: 'name', type: 'string' },
-          { name: 'wallet', type: 'address' },
-        ],
-        Mail: [
-          { name: 'from', type: 'Person' },
-          { name: 'to', type: 'Person' },
-          { name: 'contents', type: 'string' },
-        ],
-      },
-      primaryType: 'Mail',
-      domain: {
-        name: 'Ether Mail',
-        version: '1',
-        chainId: 1,
-        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
-      },
-      message: {
-        from: {
-          name: 'Cow',
-          wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
-        },
-        to: {
-          name: 'Bob',
-          wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
-        },
-        contents: 'Hello, Bob!',
-      },
-    }`
-
-    render(
-      <SignMessageModal
-        isOpen
-        safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
-        message={typedMessageStr}
-        safeName="test safe"
-        ethBalance="100000000000000000"
-        onClose={onCloseFn}
-        onUserConfirm={jest.fn()}
-        onTxReject={jest.fn()}
-        requestId="1"
-        method={Methods.signTypedMessage}
-        app={getEmptySafeApp()}
-      />,
-    )
-    expect(onCloseFn).toHaveBeenCalled()
-  })
-
   test('If message is invalid typed data, modal should be closed', () => {
     const onCloseFn = jest.fn()
-    const typedMessageStr = `{"test": "test"}`
+    const typedMessageStr = { test: 'test' }
 
     render(
       <SignMessageModal
         isOpen
         safeAddress="0x1948fC557ed7219D33138bD2cD52Da7F2047B2bb"
+        // @ts-expect-error - invalid typed message
         message={typedMessageStr}
         safeName="test safe"
         ethBalance="100000000000000000"

--- a/src/routes/safe/components/Apps/hooks/useSignMessageModal.ts
+++ b/src/routes/safe/components/Apps/hooks/useSignMessageModal.ts
@@ -1,7 +1,12 @@
 import { useState, useCallback } from 'react'
-import { Methods } from '@gnosis.pm/safe-apps-sdk'
+import { EIP712TypedData, Methods } from '@gnosis.pm/safe-apps-sdk'
 
-type StateType = { isOpen: boolean; message: string; requestId: string; method: Methods }
+type StateType = {
+  isOpen: boolean
+  requestId: string
+  message: string | EIP712TypedData
+  method: Methods.signMessage | Methods.signTypedMessage
+}
 
 const INITIAL_MODAL_STATE: StateType = {
   isOpen: false,
@@ -10,20 +15,27 @@ const INITIAL_MODAL_STATE: StateType = {
   method: Methods.signMessage,
 }
 
-type ReturnType = [StateType, (message: string, requestId: string, method: Methods) => void, () => void]
+type ReturnType = [
+  StateType,
+  (message: string | EIP712TypedData, requestId: string, method: Methods) => void,
+  () => void,
+]
 
 export const useSignMessageModal = (): ReturnType => {
   const [signMessageModalState, setSignMessageModalState] = useState<StateType>(INITIAL_MODAL_STATE)
 
-  const openSignMessageModal = useCallback((message: string, requestId: string, method: Methods) => {
-    setSignMessageModalState({
-      ...INITIAL_MODAL_STATE,
-      isOpen: true,
-      message,
-      requestId,
-      method,
-    })
-  }, [])
+  const openSignMessageModal = useCallback(
+    (message: string | EIP712TypedData, requestId: string, method: Methods.signTypedMessage | Methods.signMessage) => {
+      setSignMessageModalState({
+        ...INITIAL_MODAL_STATE,
+        isOpen: true,
+        message,
+        requestId,
+        method,
+      })
+    },
+    [],
+  )
 
   const closeSignMessageModal = useCallback(() => {
     setSignMessageModalState(INITIAL_MODAL_STATE)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2155,6 +2155,14 @@
     "@gnosis.pm/safe-react-gateway-sdk" "^2.5.6"
     ethers "^5.4.7"
 
+"@gnosis.pm/safe-apps-sdk@7.8.0":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-7.8.0.tgz#295ab9d563b94208e3042495cdba787fa035c71e"
+  integrity sha512-kO8fJi1ebiKN9qH1NdDToVBuDQQ0U9NkL467U+84LtNTx5PzUJIu6O7tb4nZD24e/OItinf5W8GDWhhfZeiqOA==
+  dependencies:
+    "@gnosis.pm/safe-react-gateway-sdk" "^3.1.3"
+    ethers "^5.6.8"
+
 "@gnosis.pm/safe-apps-sdk@^6.2.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-6.3.0.tgz#19f8bff136bdfdf9003745e4202e1cb85322e493"
@@ -2162,19 +2170,6 @@
   dependencies:
     "@gnosis.pm/safe-react-gateway-sdk" "^2.8.5"
     ethers "^5.4.7"
-
-"@gnosis.pm/safe-apps-sdk@file:.yalc/@gnosis.pm/safe-apps-sdk":
-  version "7.7.0"
-  dependencies:
-    "@gnosis.pm/safe-react-gateway-sdk" "^3.1.3"
-    ethers "^5.6.8"
-
-"@gnosis.pm/safe-apps-sdk@https://gitpkg.now.sh/safe-global/safe-apps-sdk/packages/safe-apps-sdk?fix/eip712-signing":
-  version "7.7.0"
-  resolved "https://gitpkg.now.sh/safe-global/safe-apps-sdk/packages/safe-apps-sdk?fix/eip712-signing#5752014774d848556a3dca32afabc2adf5e04207"
-  dependencies:
-    "@gnosis.pm/safe-react-gateway-sdk" "^3.1.3"
-    ethers "^5.6.8"
 
 "@gnosis.pm/safe-core-sdk-types@1.0.0", "@gnosis.pm/safe-core-sdk-types@^1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2155,14 +2155,6 @@
     "@gnosis.pm/safe-react-gateway-sdk" "^2.5.6"
     ethers "^5.4.7"
 
-"@gnosis.pm/safe-apps-sdk@7.7.0":
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-7.7.0.tgz#dc3621634bd42f1d24cbe4342fd85592cd1491cd"
-  integrity sha512-MuiH09q/5DFfHQLrwNW7JSvGEMGqrS3jNJy9UKZHW77rxzmZssHX1l3+p5whTbtrcvLbxQgcp5egMrdw/sj0qw==
-  dependencies:
-    "@gnosis.pm/safe-react-gateway-sdk" "^3.1.3"
-    ethers "^5.6.8"
-
 "@gnosis.pm/safe-apps-sdk@^6.2.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-6.3.0.tgz#19f8bff136bdfdf9003745e4202e1cb85322e493"
@@ -2170,6 +2162,19 @@
   dependencies:
     "@gnosis.pm/safe-react-gateway-sdk" "^2.8.5"
     ethers "^5.4.7"
+
+"@gnosis.pm/safe-apps-sdk@file:.yalc/@gnosis.pm/safe-apps-sdk":
+  version "7.7.0"
+  dependencies:
+    "@gnosis.pm/safe-react-gateway-sdk" "^3.1.3"
+    ethers "^5.6.8"
+
+"@gnosis.pm/safe-apps-sdk@https://gitpkg.now.sh/safe-global/safe-apps-sdk/packages/safe-apps-sdk?fix/eip712-signing":
+  version "7.7.0"
+  resolved "https://gitpkg.now.sh/safe-global/safe-apps-sdk/packages/safe-apps-sdk?fix/eip712-signing#5752014774d848556a3dca32afabc2adf5e04207"
+  dependencies:
+    "@gnosis.pm/safe-react-gateway-sdk" "^3.1.3"
+    ethers "^5.6.8"
 
 "@gnosis.pm/safe-core-sdk-types@1.0.0", "@gnosis.pm/safe-core-sdk-types@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
## What it solves
This PR fixes bugs found in the EIP712 signing found by the 1inch team. They're the following:
- Unnecessary wrapping of the EIP712 typed data with Safe's EIP712 message structure
- Unnecessary JSON wraps/unwraps of the EIP712 data 

## How to test it
1. Run https://github.com/gnosis/safe-test-app/pull/2
2. Use a test message, it should be a valid JSON. Example:
```
{"domain":{"verifyingContract":"0x0000000000000000000000000000000000000777","chainId":1},"message":{"message":"0x"},"types":{"SafeMessage":[{"type":"bytes","name":"message"}]}}
```
3. Paste it into the textarea
4. Click a button to sign it
5. Confirm that the message matches your test message
6. Sign and execute the signing
7. Check if the message is signed by clicking the button in the test app

Related SDK PR https://github.com/safe-global/safe-apps-sdk/pull/361
