### PR TITLE
fix: Update claming app url

### DIFF
--- a/src/components/AppLayout/Header/components/SafeTokenWidget/index.tsx
+++ b/src/components/AppLayout/Header/components/SafeTokenWidget/index.tsx
@@ -15,7 +15,7 @@ import Track from 'src/components/Track'
 import { OVERVIEW_EVENTS } from 'src/utils/events/overview'
 
 // TODO: once listed on safe apps list, get the url from there?
-const CLAIMING_APP_URL = 'https://safe-claiming-app.pages.dev/'
+const CLAIMING_APP_URL = 'https://safe-apps.dev.gnosisdev.com/safe-claiming-app/'
 
 export const getSafeTokenAddress = (chainId: string): string => {
   return SAFE_TOKEN_ADDRESSES[chainId]


### PR DESCRIPTION
## What it solves

Updates the safe claiming app url for the token widget in the header

## How to test

1. Open the safe
2. Press on the token widget in the header
3. Observe being navigated to the safe claiming app
