### PR TITLE
fix: use app id to fetch claiming app url

### DIFF
--- a/src/components/AppLayout/Header/components/SafeTokenWidget/index.tsx
+++ b/src/components/AppLayout/Header/components/SafeTokenWidget/index.tsx
@@ -16,7 +16,6 @@ import { OVERVIEW_EVENTS } from 'src/utils/events/overview'
 import { useAppList } from 'src/routes/safe/components/Apps/hooks/appList/useAppList'
 
 const isStaging = !IS_PRODUCTION && !isProdGateway()
-// TODO: once listed on safe apps list, get the url from there?
 const CLAIMING_APP_ID = isStaging ? '61' : '95'
 
 export const getSafeTokenAddress = (chainId: string): string => {
@@ -64,11 +63,11 @@ const SafeTokenWidget = (): JSX.Element | null => {
   })
 
   const tokenAddress = getSafeTokenAddress(chainId)
-  if (!tokenAddress) {
+  if (!tokenAddress || !claimingApp) {
     return null
   }
 
-  const url = claimingApp ? `${appsPath}?appUrl=${encodeURI(claimingApp.url)}` : undefined
+  const url = `${appsPath}?appUrl=${encodeURI(claimingApp.url)}`
 
   const safeBalance = safeTokens.find((balanceItem) => {
     return balanceItem.address === tokenAddress
@@ -79,14 +78,9 @@ const SafeTokenWidget = (): JSX.Element | null => {
 
   return (
     <StyledWrapper>
-      <Tooltip title={claimingApp ? `Open ${claimingApp.name}` : ''}>
+      <Tooltip title={`Open ${claimingApp.name}`}>
         <Track {...OVERVIEW_EVENTS.SAFE_TOKEN_WIDGET}>
-          <ButtonBase
-            href={url || '#'}
-            aria-describedby={'safe-token-widget'}
-            style={buttonStyle}
-            disabled={url === undefined}
-          >
+          <ButtonBase href={url || '#'} aria-describedby={'safe-token-widget'} style={buttonStyle}>
             <Img alt="Safe token" src={SafeTokenIcon} />
             <Text size="xl" strong>
               {flooredSafeBalance}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -46,7 +46,7 @@ export const LS_SEPARATOR = '__'
 export const LS_USE_PROD_CGW = 'useProdGateway'
 
 // For debugging on dev
-const isProdGateway = () => {
+export const isProdGateway = () => {
   try {
     return localStorage.getItem(`${LS_NAMESPACE}${LS_SEPARATOR}${LS_USE_PROD_CGW}`) === 'true'
   } catch (e) {


### PR DESCRIPTION
## What it solves
Uses the app ID from staging `61` and production `95` to fetch the app URL for the claiming app.

## How this PR fixes it

## How to test it
Click the token widget.
Hint: For prod the id exists but its disabled and not yet returned by the config service. But as soon as it gets enabled it should work.

## Analytics changes
None
