### PR TITLE
fix: Display non-transfer warning when selecting safe token

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
@@ -4,7 +4,7 @@ import { BigNumber } from 'bignumber.js'
 import { ReactElement, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 
-import { getExplorerInfo, getNativeCurrency } from 'src/config'
+import { _getChainId, getExplorerInfo, getNativeCurrency } from 'src/config'
 import Field from 'src/components/forms/Field'
 import GnoForm from 'src/components/forms/GnoForm'
 import TextField from 'src/components/forms/TextField'
@@ -47,6 +47,9 @@ import { Modal } from 'src/components/Modal'
 import { ModalHeader } from '../ModalHeader'
 import { isSpendingLimit } from 'src/routes/safe/components/Transactions/helpers/utils'
 import { getStepTitle } from 'src/routes/safe/components/Balances/SendModal/utils'
+import { getSafeTokenAddress } from 'src/components/AppLayout/Header/components/SafeTokenWidget'
+import InfoIcon from 'src/assets/icons/info_red.svg'
+import Img from 'src/components/layout/Img'
 
 const formMutators = {
   setMax: (args, state, utils) => {
@@ -199,6 +202,10 @@ const SendFunds = ({
             tokenAddress: selectedToken?.address,
           })
 
+          const chainId = _getChainId()
+          const safeTokenAddress = getSafeTokenAddress(chainId)
+          const isSafeTokenSelected = sameAddress(safeTokenAddress, selectedToken?.address)
+
           const handleScan = (value, closeQrModal) => {
             let scannedAddress = value
 
@@ -221,10 +228,7 @@ const SendFunds = ({
             closeQrModal()
           }
 
-          let shouldDisableSubmitButton = !isValidAddress
-          if (selectedEntry) {
-            shouldDisableSubmitButton = !selectedEntry.address
-          }
+          const shouldDisableSubmitButton = !isValidAddress || isSafeTokenSelected || !selectedEntry?.address
 
           const setMaxAllowedAmount = () => {
             const isSpendingLimitTx = tokenSpendingLimit && isSpendingLimit(txType)
@@ -302,6 +306,14 @@ const SendFunds = ({
                     />
                   </Col>
                 </Row>
+                {isSafeTokenSelected && (
+                  <Row align="center" margin="md">
+                    <Paragraph color="error" noMargin className={classes.warningRow}>
+                      <Img height={16} src={InfoIcon} className={classes.warningIcon} />
+                      SAFE is currently non-transferable.
+                    </Paragraph>
+                  </Row>
+                )}
                 {tokenSpendingLimit && selectedToken && (
                   <SpendingLimitRow selectedToken={selectedToken} tokenSpendingLimit={tokenSpendingLimit} />
                 )}

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/index.tsx
@@ -228,7 +228,10 @@ const SendFunds = ({
             closeQrModal()
           }
 
-          const shouldDisableSubmitButton = !isValidAddress || isSafeTokenSelected || !selectedEntry?.address
+          let shouldDisableSubmitButton = !isValidAddress || isSafeTokenSelected
+          if (selectedEntry) {
+            shouldDisableSubmitButton = !selectedEntry.address || isSafeTokenSelected
+          }
 
           const setMaxAllowedAmount = () => {
             const isSpendingLimitTx = tokenSpendingLimit && isSpendingLimit(txType)

--- a/src/routes/safe/components/Balances/SendModal/screens/SendFunds/style.ts
+++ b/src/routes/safe/components/Balances/SendModal/screens/SendFunds/style.ts
@@ -1,4 +1,4 @@
-import { lg, md } from 'src/theme/variables'
+import { lg, md, sm } from 'src/theme/variables'
 import { createStyles } from '@material-ui/core'
 
 export const styles = createStyles({
@@ -19,5 +19,12 @@ export const styles = createStyles({
   },
   selectAddress: {
     cursor: 'pointer',
+  },
+  warningRow: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  warningIcon: {
+    marginRight: sm,
   },
 })


### PR DESCRIPTION
## What it solves

The SAFE Token is currently paused so we display a non-transfer warning and disable the Submit button

## How to test it

1. Open a safe that has Safe Tokens
2. Create a new transaction
3. Select the Safe Token
4. Observe an error message below the token field
5. Observe the Review Button is disabled
