### PR TITLE
fix: retrieve `chainId` from store to rerender token widget

### DIFF
--- a/src/components/AppLayout/Header/components/Layout.tsx
+++ b/src/components/AppLayout/Header/components/Layout.tsx
@@ -21,7 +21,7 @@ import Track from 'src/components/Track'
 import Notifications from 'src/components/AppLayout/Header/components/Notifications'
 import AnimatedLogo from 'src/components/AppLayout/Header/components/AnimatedLogo'
 import SafeTokenWidget, { getSafeTokenAddress } from './SafeTokenWidget'
-import { _getChainId } from 'src/config'
+import { currentChainId } from 'src/logic/config/store/selectors'
 
 const styles = () => ({
   root: {
@@ -103,7 +103,7 @@ const Layout = ({ classes, providerDetails, providerInfo }) => {
   const { clickAway: clickAwayWallet, open: openWallet, toggle: toggleWallet } = useStateHandler()
   const { clickAway: clickAwayNetworks, open: openNetworks, toggle: toggleNetworks } = useStateHandler()
   const isWrongChain = useSelector(shouldSwitchWalletChain)
-  const chainId = _getChainId()
+  const chainId = useSelector(currentChainId)
   const chainHasSafeToken = Boolean(getSafeTokenAddress(chainId))
 
   return (

--- a/src/components/AppLayout/Header/components/SafeTokenWidget/index.tsx
+++ b/src/components/AppLayout/Header/components/SafeTokenWidget/index.tsx
@@ -2,7 +2,7 @@ import { Box, ButtonBase } from '@material-ui/core'
 import { Text, Tooltip } from '@gnosis.pm/safe-react-components'
 import { useSelector } from 'react-redux'
 import Img from 'src/components/layout/Img'
-import { getShortName, _getChainId } from 'src/config'
+import { getShortName } from 'src/config'
 import useSafeAddress from 'src/logic/currentSession/hooks/useSafeAddress'
 import { formatAmount } from 'src/logic/tokens/utils/formatAmount'
 import { generateSafeRoute, SAFE_ROUTES } from 'src/routes/routes'
@@ -16,6 +16,7 @@ import { OVERVIEW_EVENTS } from 'src/utils/events/overview'
 import { useAppList } from 'src/routes/safe/components/Apps/hooks/appList/useAppList'
 import useSafeTokenAllocation from 'src/components/AppLayout/Header/components/SafeTokenWidget/useSafeTokenAllocation'
 import { fromTokenUnit } from 'src/logic/tokens/utils/humanReadableValue'
+import { currentChainId } from 'src/logic/config/store/selectors'
 
 const isStaging = !IS_PRODUCTION && !isProdGateway()
 export const CLAIMING_APP_ID = isStaging ? '61' : '95'
@@ -53,7 +54,7 @@ const SafeTokenWidget = (): JSX.Element | null => {
   const { allApps } = useAppList()
   const claimingApp = allApps.find((app) => app.id === CLAIMING_APP_ID)
 
-  const chainId = _getChainId()
+  const chainId = useSelector(currentChainId)
 
   const { safeAddress } = useSafeAddress()
   if (!safeAddress) {

--- a/src/logic/safe/api/fetchSafeApps.ts
+++ b/src/logic/safe/api/fetchSafeApps.ts
@@ -1,9 +1,7 @@
 import { getSafeApps, SafeAppData } from '@gnosis.pm/safe-react-gateway-sdk'
 
-import { _getChainId } from 'src/config'
-
-export const fetchSafeAppsList = async (): Promise<SafeAppData[]> => {
-  return getSafeApps(_getChainId(), {
+export const fetchSafeAppsList = async (chainId: string): Promise<SafeAppData[]> => {
+  return getSafeApps(chainId, {
     client_url: window.location.origin,
   })
 }


### PR DESCRIPTION
## What it solves

Hidden token widget

## How this PR fixes it

The `chainId` is retrieved from the store instead of the local cache in order to rerender the widget.

## How to test it

Open the Safe on a non-claiming app chain and switch to one that has it. The token should appear. Switching back should make it disappear.

## Screenshots

![token](https://user-images.githubusercontent.com/20442784/194296280-a73c0550-124d-4dd6-9c15-e1353a6d0ffe.gif)