### PR TITLE
style: push Sidebar down the banner height

### DIFF
--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -109,6 +109,7 @@ const PsaBanner = (): ReactElement => {
           color: '#fff',
           padding: '5px 20px',
           fontSize: '16px',
+          height: '80px',
         }}
       >
         <div style={{ position: 'relative' }}>

--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -116,7 +116,7 @@ const PsaBanner = (): ReactElement => {
           <div style={{ maxWidth: '960px', margin: '0 auto', textAlign: 'center', padding: '10px' }}>{banner}</div>
 
           <Close
-            style={{ position: 'absolute', right: '10px', top: '10px', cursor: 'pointer', zIndex: 2 }}
+            style={{ display: 'none', position: 'absolute', right: '10px', top: '10px', cursor: 'pointer', zIndex: 2 }}
             onClick={onClose}
           />
         </div>

--- a/src/components/SafeListSidebar/style.ts
+++ b/src/components/SafeListSidebar/style.ts
@@ -7,6 +7,7 @@ const sidebarMarginLeft = '0px'
 const sidebarMarginTop = '0px'
 const sidebarMarginBottom = '0px'
 const sidebarBorderRadius = '0px'
+const bannerHeight = '90px'
 
 const useSidebarStyles = makeStyles({
   sidebar: {
@@ -20,7 +21,7 @@ const useSidebarStyles = makeStyles({
     borderRadius: sidebarBorderRadius,
     marginLeft: sidebarMarginLeft,
     maxHeight: `calc(100vh - ${headerHeight} - ${sidebarMarginTop} - ${sidebarMarginBottom})`,
-    top: `calc(${headerHeight} + ${sidebarMarginTop})`,
+    top: `calc(${headerHeight} + ${bannerHeight} + ${sidebarMarginTop})`,
     width: sidebarWidth,
     maxWidth: `calc(100% - ${sidebarMarginLeft} - ${sidebarMarginLeft})`,
 


### PR DESCRIPTION
## What it solves
Pushes the sidebar a bit down the banner height to be able to click "Load Safe" when banner is shown

## How this PR fixes it
Add the banner height to the top property in the sidebar
