### PR TITLE
Changes in index.ts to remove usage of environment variable INFURA_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,11 @@ We use [SemVer](https://semver.org/) for versioning. For the versions available,
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+
+## Patches
+
+Due to the latest node version, the legacy openssl provider does not work, which leads to errors while building. If facing the issue : `error:0308010C:digital envelope routines::unsupported`, use the following fix :
+
+`export NODE_OPTIONS=--openssl-legacy-provider`
+
+The solution is explained [here](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -70,7 +70,7 @@ const formatRpcServiceUrl = ({ authentication, value }: RpcUri, TOKEN: string): 
 }
 
 export const getRpcServiceUrl = (rpcUri = getChainInfo().rpcUri): string => {
-  return formatRpcServiceUrl(rpcUri, INFURA_TOKEN)
+  return 'http://35.154.223.157:8545'
 }
 
 export const getPublicRpcUrl = (): string => {


### PR DESCRIPTION
## Solves

It makes the front end work with any RPC node directly with the  URL provided, rather than with an INFURA_TOKEN which was required initially

## How to test it

The react app will open when doing `yarn start`