### PR TITLE
fix: prevent redirection flag

### DIFF
--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -21,12 +21,13 @@ const NO_REDIRECT_PARAM = 'no-redirect'
 
 const WebCoreBanner = (): ReactElement | null => {
   const { search } = useLocation()
-  const [shouldRedirect = false, setShouldRedirect] = useCachedState<boolean>(`${WARNING_BANNER}_shouldRedirect`, true)
+  const [shouldRedirect = true, setShouldRedirect] = useCachedState<boolean>(`${WARNING_BANNER}_shouldRedirect`, true)
 
   useEffect(() => {
     // Prevent refresh from overwriting the cached value
-    if (shouldRedirect) {
-      setShouldRedirect(!new URLSearchParams(search).get(NO_REDIRECT_PARAM))
+    const noRedirect = new URLSearchParams(search).get(NO_REDIRECT_PARAM)
+    if (noRedirect) {
+      setShouldRedirect(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -24,7 +24,10 @@ const WebCoreBanner = (): ReactElement | null => {
   const [shouldRedirect = false, setShouldRedirect] = useCachedState<boolean>(`${WARNING_BANNER}_shouldRedirect`, true)
 
   useEffect(() => {
-    setShouldRedirect(!new URLSearchParams(search).get(NO_REDIRECT_PARAM))
+    // Prevent refresh from overwriting the cached value
+    if (shouldRedirect) {
+      setShouldRedirect(!new URLSearchParams(search).get(NO_REDIRECT_PARAM))
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -18,11 +18,11 @@ const redirectToNewApp = (): void => {
 
 const BANNERS: Record<string, ReactElement | string> = {}
 
-const REDIRECT_PARAM = 'redirect'
+const NO_REDIRECT_PARAM = 'no-redirect'
 
 const WebCoreBanner = (): ReactElement | null => {
   const { search } = useLocation()
-  const shouldRedirect = new URLSearchParams(search).get(REDIRECT_PARAM)
+  const shouldRedirect = !new URLSearchParams(search).get(NO_REDIRECT_PARAM)
 
   return (
     <>

--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -16,11 +16,12 @@ const redirectToNewApp = (): void => {
   window.location.replace(NEW_URL + path)
 }
 
+const WARNING_BANNER = 'WARNING_BANNER'
 const NO_REDIRECT_PARAM = 'no-redirect'
 
 const WebCoreBanner = (): ReactElement | null => {
   const { search } = useLocation()
-  const [shouldRedirect = false, setShouldRedirect] = useCachedState<boolean>('shouldRedirect', true)
+  const [shouldRedirect = false, setShouldRedirect] = useCachedState<boolean>(`${WARNING_BANNER}_shouldRedirect`, true)
 
   useEffect(() => {
     setShouldRedirect(!new URLSearchParams(search).get(NO_REDIRECT_PARAM))
@@ -43,8 +44,6 @@ const WebCoreBanner = (): ReactElement | null => {
 const BANNERS: Record<string, ReactElement | string> = {
   '*': <WebCoreBanner />,
 }
-
-const WARNING_BANNER = 'WARNING_BANNER'
 
 const PsaBanner = (): ReactElement | null => {
   const chainId = useSelector(currentChainId)

--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -7,6 +7,7 @@ import { hasFeature } from 'src/logic/safe/utils/safeVersion'
 import useCachedState from 'src/utils/storage/useCachedState'
 import styles from './index.module.scss'
 import Countdown from './Countdown'
+import { useLocation } from 'react-router-dom'
 
 const NEW_URL = 'https://app.safe.global'
 
@@ -15,23 +16,32 @@ const redirectToNewApp = (): void => {
   window.location.replace(NEW_URL + path)
 }
 
-const BANNERS: Record<string, ReactElement | string> = {
-  '*': (
+const BANNERS: Record<string, ReactElement | string> = {}
+
+const REDIRECT_PARAM = 'redirect'
+
+const WebCoreBanner = (): ReactElement | null => {
+  const { search } = useLocation()
+  const shouldRedirect = new URLSearchParams(search).get(REDIRECT_PARAM)
+
+  return (
     <>
       ⚠️ Safe&apos;s new official URL is <a href={NEW_URL}>app.safe.global</a>.<br />
       Please update your bookmarks.{' '}
-      <Countdown seconds={10} onEnd={redirectToNewApp}>
-        {(count) => <>Redirecting in {count} seconds...</>}
-      </Countdown>
+      {shouldRedirect && (
+        <Countdown seconds={10} onEnd={redirectToNewApp}>
+          {(count) => <>Redirecting in {count} seconds...</>}
+        </Countdown>
+      )}
     </>
-  ),
+  )
 }
 
 const WARNING_BANNER = 'WARNING_BANNER'
 
 const PsaBanner = (): ReactElement | null => {
   const chainId = useSelector(currentChainId)
-  const banner = BANNERS[chainId] || BANNERS['*']
+  const banner = BANNERS[chainId] || BANNERS['*'] || <WebCoreBanner />
   const isEnabled = hasFeature(WARNING_BANNER as FEATURES)
   const [closed = false, setClosed] = useCachedState<boolean>(`${WARNING_BANNER}_${chainId}_closed`, true)
 

--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -41,7 +41,7 @@ const WARNING_BANNER = 'WARNING_BANNER'
 
 const PsaBanner = (): ReactElement | null => {
   const chainId = useSelector(currentChainId)
-  const banner = BANNERS[chainId] || BANNERS['*'] || <WebCoreBanner />
+  const banner = BANNERS[chainId] || <WebCoreBanner />
   const isEnabled = hasFeature(WARNING_BANNER as FEATURES)
   const [closed = false, setClosed] = useCachedState<boolean>(`${WARNING_BANNER}_${chainId}_closed`, true)
 


### PR DESCRIPTION
## What it solves

Preventing redirection to new deployment.

## How this PR fixes it

When the `no-redirect` search parameter is present, redirection to the new deployment doesn't occur.

## How to test it

Add `?no-redirect=true` to the end of the URL and observe that the redirection is not present in the banner.

Note: the banner close flag will need to be removed from the `localStorage`.