### PR TITLE
fix: Add export data button to settings page

### DIFF
--- a/src/routes/export/Export.tsx
+++ b/src/routes/export/Export.tsx
@@ -1,0 +1,17 @@
+import { ReactElement } from 'react'
+
+import Page from 'src/components/layout/Page'
+import Block from 'src/components/layout/Block'
+import DataExport from 'src/routes/safe/components/Settings/DataExport'
+
+function Export(): ReactElement {
+  return (
+    <Page>
+      <Block>
+        <DataExport />
+      </Block>
+    </Page>
+  )
+}
+
+export default Export

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -17,6 +17,7 @@ import {
   SAFE_ROUTES,
   GENERIC_APPS_ROUTE,
   SAFE_APP_LANDING_PAGE_ROUTE,
+  EXPORT_ROUTE,
 } from './routes'
 import { setChainId } from 'src/logic/config/utils'
 import { setChainIdFromUrl } from 'src/utils/history'
@@ -28,6 +29,7 @@ const CreateSafePage = React.lazy(() => import('./CreateSafePage/CreateSafePage'
 const LoadSafePage = React.lazy(() => import('./LoadSafePage/LoadSafePage'))
 const SafeAppLandingPage = React.lazy(() => import('./SafeAppLandingPage/SafeAppLandingPage'))
 const SafeContainer = React.lazy(() => import('./safe/container'))
+const Export = React.lazy(() => import('./export/Export'))
 
 const Routes = (): React.ReactElement => {
   const location = useLocation()
@@ -116,6 +118,8 @@ const Routes = (): React.ReactElement => {
       />
 
       <Route component={Welcome} exact path={WELCOME_ROUTE} />
+
+      <Route component={Export} exact path={EXPORT_ROUTE} />
 
       <Route component={CreateSafePage} exact path={OPEN_SAFE_ROUTE} />
 

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -46,6 +46,7 @@ export const OPEN_SAFE_ROUTE = '/open'
 export const GENERIC_APPS_ROUTE = '/apps'
 export const LOAD_SAFE_ROUTE = generatePath(LOAD_SPECIFIC_SAFE_ROUTE) // By providing no slug, we get '/load'
 export const SAFE_APP_LANDING_PAGE_ROUTE = '/share/safe-app'
+export const EXPORT_ROUTE = '/export'
 
 // [SAFE_SECTION_SLUG], [SAFE_SUBSECTION_SLUG] populated safe routes
 export const SAFE_ROUTES = {

--- a/src/routes/safe/components/Settings/DataExport/index.tsx
+++ b/src/routes/safe/components/Settings/DataExport/index.tsx
@@ -3,11 +3,13 @@ import Button from 'src/components/layout/Button'
 import Heading from 'src/components/layout/Heading'
 import Paragraph from 'src/components/layout/Paragraph'
 
+const EXPORT_VERSION = '1.0'
+
 const DataExport = (): ReactElement => {
   const handleExport = () => {
     const filename = `safe-data-${new Date().toISOString().slice(0, 10)}.json`
 
-    const data = JSON.stringify({ version: '1.0', data: localStorage })
+    const data = JSON.stringify({ version: EXPORT_VERSION, data: localStorage })
 
     const blob = new Blob([data], { type: 'text/json' })
     const link = document.createElement('a')

--- a/src/routes/safe/components/Settings/DataExport/index.tsx
+++ b/src/routes/safe/components/Settings/DataExport/index.tsx
@@ -1,0 +1,77 @@
+import { ReactElement } from 'react'
+import { useSelector } from 'react-redux'
+import Button from 'src/components/layout/Button'
+import { addressBookState } from 'src/logic/addressBook/store/selectors'
+import { SafeRecordWithNames, safesWithNamesAsList } from 'src/logic/safe/store/selectors'
+import { AddressBookState } from 'src/logic/addressBook/model/addressBook'
+import { isValidAddress } from 'src/utils/isValidAddress'
+
+// Returns address book data in the format of web-core
+const parseAddressBook = (addressBook: AddressBookState) => {
+  const newAb = addressBook.reduce((acc, { address, name, chainId }) => {
+    if (!name || !address || !isValidAddress(address)) {
+      return acc
+    }
+    acc[chainId] = acc[chainId] || {}
+    acc[chainId][address] = name
+    return acc
+  }, {})
+
+  return Object.keys(newAb).length > 0 ? newAb : {}
+}
+
+// Returns added safe data in the format of web-core
+const parseAddedSafes = (safes: SafeRecordWithNames[]) => {
+  const newAddedSafes = {}
+
+  for (const safe of safes) {
+    if (!safe.chainId) {
+      continue
+    }
+
+    if (!newAddedSafes[safe.chainId]) {
+      newAddedSafes[safe.chainId] = {}
+    }
+
+    newAddedSafes[safe.chainId][safe.address] = {
+      owners: safe.owners,
+      threshold: safe.threshold,
+      ethBalance: safe.ethBalance,
+    }
+  }
+
+  return newAddedSafes
+}
+
+const DataExport = (): ReactElement => {
+  const addressBook = useSelector(addressBookState)
+  const safes = useSelector(safesWithNamesAsList)
+
+  const handleExport = () => {
+    const filename = `safe-data-${new Date().toISOString().slice(0, 10)}.json`
+
+    const ABData = parseAddressBook(addressBook)
+    const safesData = parseAddedSafes(safes)
+
+    const data = JSON.stringify({
+      SAFE_v2__addedSafes: safesData,
+      SAFE_v2__addressBook: ABData,
+    })
+
+    const blob = new Blob([data], { type: 'text/json' })
+    const link = document.createElement('a')
+
+    link.download = filename
+    link.href = window.URL.createObjectURL(blob)
+    link.dataset.downloadurl = ['text/json', link.download, link.href].join(':')
+    link.dispatchEvent(new MouseEvent('click'))
+  }
+
+  return (
+    <Button onClick={handleExport} color="primary" size="small" variant="outlined">
+      Download
+    </Button>
+  )
+}
+
+export default DataExport

--- a/src/routes/safe/components/Settings/DataExport/index.tsx
+++ b/src/routes/safe/components/Settings/DataExport/index.tsx
@@ -1,5 +1,7 @@
 import { ReactElement } from 'react'
 import Button from 'src/components/layout/Button'
+import Heading from 'src/components/layout/Heading'
+import Paragraph from 'src/components/layout/Paragraph'
 
 const DataExport = (): ReactElement => {
   const handleExport = () => {
@@ -17,9 +19,15 @@ const DataExport = (): ReactElement => {
   }
 
   return (
-    <Button onClick={handleExport} color="primary" size="small" variant="outlined">
-      Download
-    </Button>
+    <>
+      <Heading tag="h2">Export your data</Heading>
+      <Paragraph>
+        Download your local storage data with your added Safes and address book. You can import it on app.safe.global.
+      </Paragraph>
+      <Button onClick={handleExport} color="primary" size="small" variant="outlined">
+        Download
+      </Button>
+    </>
   )
 }
 

--- a/src/routes/safe/components/Settings/DataExport/index.tsx
+++ b/src/routes/safe/components/Settings/DataExport/index.tsx
@@ -24,7 +24,7 @@ const DataExport = (): ReactElement => {
     <>
       <Heading tag="h2">Export your data</Heading>
       <Paragraph>
-        Download your local storage data with your added Safes and address book. You can import it on app.safe.global.
+        Download your local data with your added Safes and address book. You can import it on app.safe.global.
       </Paragraph>
       <Button onClick={handleExport} color="primary" size="small" variant="outlined">
         Download

--- a/src/routes/safe/components/Settings/DataExport/index.tsx
+++ b/src/routes/safe/components/Settings/DataExport/index.tsx
@@ -1,62 +1,11 @@
 import { ReactElement } from 'react'
-import { useSelector } from 'react-redux'
 import Button from 'src/components/layout/Button'
-import { addressBookState } from 'src/logic/addressBook/store/selectors'
-import { SafeRecordWithNames, safesWithNamesAsList } from 'src/logic/safe/store/selectors'
-import { AddressBookState } from 'src/logic/addressBook/model/addressBook'
-import { isValidAddress } from 'src/utils/isValidAddress'
-
-// Returns address book data in the format of web-core
-const parseAddressBook = (addressBook: AddressBookState) => {
-  const newAb = addressBook.reduce((acc, { address, name, chainId }) => {
-    if (!name || !address || !isValidAddress(address)) {
-      return acc
-    }
-    acc[chainId] = acc[chainId] || {}
-    acc[chainId][address] = name
-    return acc
-  }, {})
-
-  return Object.keys(newAb).length > 0 ? newAb : {}
-}
-
-// Returns added safe data in the format of web-core
-const parseAddedSafes = (safes: SafeRecordWithNames[]) => {
-  const newAddedSafes = {}
-
-  for (const safe of safes) {
-    if (!safe.chainId) {
-      continue
-    }
-
-    if (!newAddedSafes[safe.chainId]) {
-      newAddedSafes[safe.chainId] = {}
-    }
-
-    newAddedSafes[safe.chainId][safe.address] = {
-      owners: safe.owners,
-      threshold: safe.threshold,
-      ethBalance: safe.ethBalance,
-    }
-  }
-
-  return newAddedSafes
-}
 
 const DataExport = (): ReactElement => {
-  const addressBook = useSelector(addressBookState)
-  const safes = useSelector(safesWithNamesAsList)
-
   const handleExport = () => {
     const filename = `safe-data-${new Date().toISOString().slice(0, 10)}.json`
 
-    const ABData = parseAddressBook(addressBook)
-    const safesData = parseAddedSafes(safes)
-
-    const data = JSON.stringify({
-      SAFE_v2__addedSafes: safesData,
-      SAFE_v2__addressBook: ABData,
-    })
+    const data = JSON.stringify(localStorage)
 
     const blob = new Blob([data], { type: 'text/json' })
     const link = document.createElement('a')

--- a/src/routes/safe/components/Settings/DataExport/index.tsx
+++ b/src/routes/safe/components/Settings/DataExport/index.tsx
@@ -7,7 +7,7 @@ const DataExport = (): ReactElement => {
   const handleExport = () => {
     const filename = `safe-data-${new Date().toISOString().slice(0, 10)}.json`
 
-    const data = JSON.stringify(localStorage)
+    const data = JSON.stringify({ version: '1.0', data: localStorage })
 
     const blob = new Blob([data], { type: 'text/json' })
     const link = document.createElement('a')

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -190,7 +190,7 @@ const SafeDetails = (): ReactElement => {
           <Block className={classes.formContainer}>
             <Heading tag="h2">Export your data</Heading>
             <Paragraph>
-              Download your local storage data with your added safes and address book. You can import it on
+              Download your local storage data with your added Safes and address book. You can import it on
               app.safe.global.
             </Paragraph>
             <DataExport />

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -188,11 +188,6 @@ const SafeDetails = (): ReactElement => {
           )}
 
           <Block className={classes.formContainer}>
-            <Heading tag="h2">Export your data</Heading>
-            <Paragraph>
-              Download your local storage data with your added Safes and address book. You can import it on
-              app.safe.global.
-            </Paragraph>
             <DataExport />
           </Block>
 

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -190,7 +190,8 @@ const SafeDetails = (): ReactElement => {
           <Block className={classes.formContainer}>
             <Heading tag="h2">Export your data</Heading>
             <Paragraph>
-              Download your local storage data to keep your added safes and address book entries for later reimport.
+              Download your local storage data with your added safes and address book. You can import it on
+              app.safe.global.
             </Paragraph>
             <DataExport />
           </Block>

--- a/src/routes/safe/components/Settings/SafeDetails/index.tsx
+++ b/src/routes/safe/components/Settings/SafeDetails/index.tsx
@@ -35,6 +35,7 @@ import ChainIndicator from 'src/components/ChainIndicator'
 import { currentChainId } from 'src/logic/config/store/selectors'
 import { trackEvent } from 'src/utils/googleTagManager'
 import { SETTINGS_EVENTS } from 'src/utils/events/settings'
+import DataExport from 'src/routes/safe/components/Settings/DataExport'
 
 export const SAFE_NAME_INPUT_TEST_ID = 'safe-name-input'
 export const SAFE_NAME_SUBMIT_BTN_TEST_ID = 'change-safe-name-btn'
@@ -185,6 +186,14 @@ const SafeDetails = (): ReactElement => {
               </Block>
             </Block>
           )}
+
+          <Block className={classes.formContainer}>
+            <Heading tag="h2">Export your data</Heading>
+            <Paragraph>
+              Download your local storage data to keep your added safes and address book entries for later reimport.
+            </Paragraph>
+            <DataExport />
+          </Block>
 
           <Row align="end" className={classes.controlsRow} grow>
             <Col end="xs">


### PR DESCRIPTION
## What it solves
Part of https://github.com/safe-global/web-core/issues/1097

## How this PR fixes it

- Adds an export button to the settings page
- Adds a new global route `/export` that contains the same button
- Downloads a .json file containing added safes and address book entries
- The `.json` file is versioned with version `1.0` and contains a `data` key with the `localStorage` data

## How to test it

1. Open the Safe app
2. Navigate to Settings
3. Observe a section with a Download button
4. Click the button
5. Observe a `.json` file being downloaded that contains the localStorage

## Screenshots
<img width="820" alt="Screenshot 2022-11-08 at 12 51 54" src="https://user-images.githubusercontent.com/5880855/200557078-4db00545-f2f1-4685-87bf-a72513315976.png">
