### PR TITLE
fix: adjust banner text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-react",
-  "version": "3.33.1",
+  "version": "3.33.2",
   "description": "Allowing crypto users manage funds in a safer way",
   "website": "https://github.com/gnosis/safe-react#readme",
   "bugs": {

--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -14,7 +14,9 @@ const WebCoreBanner = (): ReactElement | null => {
   return (
     <>
       ⚠️ Safe&apos;s new official URL is <a href={NEW_URL}>app.safe.global</a>, with a fully rebranded and refurbished
-      application. The old app will run in parallel and we will announce its deprecation in time.
+      application.
+      <br />
+      The old app will run in parallel and we will announce its deprecation in time.
     </>
   )
 }

--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -14,7 +14,7 @@ const WebCoreBanner = (): ReactElement | null => {
   return (
     <>
       ⚠️ Safe&apos;s new official URL is <a href={NEW_URL}>app.safe.global</a>, with a fully rebranded and refurbished
-      application. The old app will run in parallel and we will announce its deprecation in time
+      application. The old app will run in parallel and we will announce its deprecation in time.
     </>
   )
 }

--- a/src/components/PsaBanner/index.tsx
+++ b/src/components/PsaBanner/index.tsx
@@ -9,17 +9,12 @@ import styles from './index.module.scss'
 
 const NEW_URL = 'https://app.safe.global'
 const WARNING_BANNER = 'WARNING_BANNER'
-const EXPORT_HELP = 'https://help.gnosis-safe.io/en/articles/5299068-address-book-export-and-import'
 
 const WebCoreBanner = (): ReactElement | null => {
   return (
     <>
-      ⚠️ Safe&apos;s new official URL is <a href={NEW_URL}>app.safe.global</a>.<br />
-      We recommend{' '}
-      <a href={EXPORT_HELP} target="_blank" rel="noreferrer">
-        exporting your address book
-      </a>{' '}
-      as CSV and importing it in the new app.
+      ⚠️ Safe&apos;s new official URL is <a href={NEW_URL}>app.safe.global</a>, with a fully rebranded and refurbished
+      application. The old app will run in parallel and we will announce its deprecation in time
     </>
   )
 }


### PR DESCRIPTION
## What it solves

Updated banner text.

## How this PR fixes it

The banner text now reads:

```
Safe's new official URL is app.safe.global, with a fully rebranded and refurbished application. The old app will run in parallel and we will announce its deprecation in time.
```

## How to test it

Open the app and observe the new banner text.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/200808124-8b85a032-fab7-4c25-b560-8a360b8fc71e.png)