### PR TITLE
Fix: add link to the new app from the export page

### DIFF
--- a/src/routes/export/Export.tsx
+++ b/src/routes/export/Export.tsx
@@ -3,12 +3,15 @@ import { ReactElement } from 'react'
 import Page from 'src/components/layout/Page'
 import Block from 'src/components/layout/Block'
 import DataExport from 'src/routes/safe/components/Settings/DataExport'
+import { Paper } from '@material-ui/core'
 
 function Export(): ReactElement {
   return (
     <Page>
       <Block>
-        <DataExport />
+        <Paper style={{ padding: '24px' }} elevation={0}>
+          <DataExport />
+        </Paper>
       </Block>
     </Page>
   )

--- a/src/routes/safe/components/Settings/DataExport/index.tsx
+++ b/src/routes/safe/components/Settings/DataExport/index.tsx
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react'
+import { Link } from '@material-ui/core'
 import Button from 'src/components/layout/Button'
 import Heading from 'src/components/layout/Heading'
 import Paragraph from 'src/components/layout/Paragraph'
@@ -24,9 +25,13 @@ const DataExport = (): ReactElement => {
     <>
       <Heading tag="h2">Export your data</Heading>
       <Paragraph>
-        Download your local data with your added Safes and address book. You can import it on app.safe.global.
+        Download your local data with your added Safes and address book. You can import it on{' '}
+        <Link target="_blank" href="https://app.safe.global/import" color="secondary">
+          app.safe.global/import
+        </Link>
+        .
       </Paragraph>
-      <Button onClick={handleExport} color="primary" size="small" variant="outlined">
+      <Button onClick={handleExport} color="primary" size="small" variant="contained">
         Download
       </Button>
     </>


### PR DESCRIPTION
## What it solves

Make the link to the new app an actual link.

<img width="1154" alt="Screenshot 2022-12-05 at 08 56 49" src="https://user-images.githubusercontent.com/381895/205583846-b31e5105-b60d-4064-adc9-12a8e67b984a.png">

See #1306.